### PR TITLE
Allow `java-version: 'dev'` for GraalVM dev builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         version: [latest, dev]
-        java-version: ['17', '19']
+        java-version: ['19']
         components: ['native-image']
         os: [macos-latest, windows-latest, ubuntu-latest]
         include:
@@ -42,6 +42,10 @@ jobs:
             java-version: '17'
             components: 'native-image'
             os: windows-2022
+          - version: 'dev'
+            java-version: 'dev'
+            components: 'native-image'
+            os: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Run setup-graalvm action
@@ -77,10 +81,19 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        version: ['22.3.0', 'latest']
-        java-version: ['11', '17', '19']
+        version: ['latest']
+        java-version: ['19']
         components: ['native-image']
         os: [macos-latest, windows-latest, ubuntu-latest]
+        include:
+          - version: '22.3.0'
+            java-version: '11'
+            components: 'native-image'
+            os: ubuntu-latest
+          - version: '22.3.0'
+            java-version: '17'
+            components: 'native-image'
+            os: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Run setup-graalvm action
@@ -172,8 +185,8 @@ jobs:
       - name: Run setup-graalvm action
         uses: ./
         with:
-          version: 'latest'
-          java-version: '19'
+          version: 'dev'
+          java-version: 'dev'
           components: 'native-image'
           native-image-musl: 'true'
           native-image-job-reports: 'true'
@@ -196,7 +209,7 @@ jobs:
       - name: Run setup-graalvm action
         uses: ./
         with:
-          version: 'dev'
+          version: 'latest'
           java-version: '17'
           components: 'espresso,llvm-toolchain,native-image,nodejs,python,R,ruby,wasm'
           set-java-home: 'false'

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ jobs:
 |-----------------|:--------:|-------------|
 | `version`<br>*(required)* | n/a | `X.Y.Z` (e.g., `22.3.0`) for a specific [GraalVM release][releases]<br>`latest` for [latest stable release][stable],<br>`dev` for [latest dev build][dev-build],<br>`mandrel-X.Y.Z` (e.g., `mandrel-21.3.0.0-Final`) for a specific [Mandrel release][mandrel-releases],<br>`mandrel-latest` for [latest Mandrel stable release][mandrel-stable]. |
 | `gds-token`     | `''`     | Download token for the GraalVM Download Service. If a non-empty token is provided, the action will set up GraalVM Enterprise Edition (see [GraalVM EE template](#basic-graalvm-enterprise-edition-template)). |
-| `java-version`<br>*(required)* | n/a | `'17'` or `'19'` for a specific Java version.<br>(`'8'`, `'11'`, `'16'` are supported for older GraalVM releases.) |
+| `java-version`<br>*(required)* | n/a | `'17'` or `'19'` for a specific Java version, `'dev'` for the highest Java version available (requires `version: 'dev'`).<br>(`'8'`, `'11'`, `'16'` are supported for older GraalVM releases.) |
 | `components`    | `''`     | Comma-spearated list of GraalVM components (e.g., `native-image` or `ruby,nodejs`) that will be installed by the [GraalVM Updater][gu]. |
 | `github-token`  | `''`     | Token for communication with the GitHub API. Please set to `${{ secrets.GITHUB_TOKEN }}` (see [templates](#templates)) to allow the action to authenticate with the GitHub API, which helps to reduce rate limiting issues. |
 | `set-java-home` | `'true'` | If set to `'true'`, instructs the action to set `$JAVA_HOME` to the path of the GraalVM installation. Overrides any previous action or command that sets `$JAVA_HOME`. |

--- a/__tests__/graalvm.test.ts
+++ b/__tests__/graalvm.test.ts
@@ -1,6 +1,9 @@
 import * as path from 'path'
 import * as graalvm from '../src/graalvm'
 import {expect, test} from '@jest/globals'
+import {getLatestRelease} from '../src/utils'
+import {findGraalVMVersion, findHighestJavaVersion} from '../src/graalvm'
+import {GRAALVM_RELEASES_REPO} from '../src/constants'
 
 process.env['RUNNER_TOOL_CACHE'] = path.join(__dirname, 'TOOL_CACHE')
 process.env['RUNNER_TEMP'] = path.join(__dirname, 'TEMP')
@@ -22,4 +25,28 @@ test('request invalid version/javaVersion', async () => {
     expect(error.message).toContain('Failed to download')
     expect(error.message).toContain('Are you sure version')
   }
+})
+
+test('find version/javaVersion', async () => {
+  const latestRelease = await getLatestRelease(GRAALVM_RELEASES_REPO)
+  const latestVersion = findGraalVMVersion(latestRelease)
+  expect(latestVersion).not.toBe('')
+  const latestJavaVersion = findHighestJavaVersion(latestRelease, latestVersion)
+  expect(latestJavaVersion).not.toBe('')
+
+  let error = new Error('unexpected')
+  try {
+    const invalidRelease = {...latestRelease, tag_name: 'invalid'}
+    findGraalVMVersion(invalidRelease)
+  } catch (err) {
+    error = err
+  }
+  expect(error.message).toContain('Could not find latest GraalVM release:')
+
+  try {
+    findHighestJavaVersion(latestRelease, 'invalid')
+  } catch (err) {
+    error = err
+  }
+  expect(error.message).toContain('Could not find highest Java version.')
 })

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -73818,7 +73818,7 @@ else {
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.EVENT_NAME_PULL_REQUEST = exports.ENV_GITHUB_EVENT_NAME = exports.GDS_GRAALVM_PRODUCT_ID = exports.GDS_BASE = exports.MANDREL_NAMESPACE = exports.JDK_HOME_SUFFIX = exports.GRAALVM_PLATFORM = exports.GRAALVM_GH_USER = exports.GRAALVM_FILE_EXTENSION = exports.GRAALVM_ARCH = exports.VERSION_LATEST = exports.VERSION_DEV = exports.IS_WINDOWS = exports.IS_MACOS = exports.IS_LINUX = exports.INPUT_NI_MUSL = exports.INPUT_CHECK_FOR_UPDATES = exports.INPUT_CACHE = exports.INPUT_SET_JAVA_HOME = exports.INPUT_GITHUB_TOKEN = exports.INPUT_COMPONENTS = exports.INPUT_JAVA_VERSION = exports.INPUT_GDS_TOKEN = exports.INPUT_VERSION = void 0;
+exports.EVENT_NAME_PULL_REQUEST = exports.ENV_GITHUB_EVENT_NAME = exports.GDS_GRAALVM_PRODUCT_ID = exports.GDS_BASE = exports.MANDREL_NAMESPACE = exports.JDK_HOME_SUFFIX = exports.GRAALVM_RELEASES_REPO = exports.GRAALVM_PLATFORM = exports.GRAALVM_GH_USER = exports.GRAALVM_FILE_EXTENSION = exports.GRAALVM_ARCH = exports.VERSION_LATEST = exports.VERSION_DEV = exports.IS_WINDOWS = exports.IS_MACOS = exports.IS_LINUX = exports.INPUT_NI_MUSL = exports.INPUT_CHECK_FOR_UPDATES = exports.INPUT_CACHE = exports.INPUT_SET_JAVA_HOME = exports.INPUT_GITHUB_TOKEN = exports.INPUT_COMPONENTS = exports.INPUT_JAVA_VERSION = exports.INPUT_GDS_TOKEN = exports.INPUT_VERSION = void 0;
 exports.INPUT_VERSION = 'version';
 exports.INPUT_GDS_TOKEN = 'gds-token';
 exports.INPUT_JAVA_VERSION = 'java-version';
@@ -73837,6 +73837,7 @@ exports.GRAALVM_ARCH = determineGraalVMArchitecture();
 exports.GRAALVM_FILE_EXTENSION = exports.IS_WINDOWS ? '.zip' : '.tar.gz';
 exports.GRAALVM_GH_USER = 'graalvm';
 exports.GRAALVM_PLATFORM = exports.IS_WINDOWS ? 'windows' : process.platform;
+exports.GRAALVM_RELEASES_REPO = 'graalvm-ce-builds';
 exports.JDK_HOME_SUFFIX = exports.IS_MACOS ? '/Contents/Home' : '';
 exports.MANDREL_NAMESPACE = 'mandrel-';
 exports.GDS_BASE = 'https://gds.oracle.com/api/20220101';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -21,6 +21,7 @@ export const GRAALVM_ARCH = determineGraalVMArchitecture()
 export const GRAALVM_FILE_EXTENSION = IS_WINDOWS ? '.zip' : '.tar.gz'
 export const GRAALVM_GH_USER = 'graalvm'
 export const GRAALVM_PLATFORM = IS_WINDOWS ? 'windows' : process.platform
+export const GRAALVM_RELEASES_REPO = 'graalvm-ce-builds'
 export const JDK_HOME_SUFFIX = IS_MACOS ? '/Contents/Home' : ''
 
 export const MANDREL_NAMESPACE = 'mandrel-'

--- a/src/features/check-for-updates.ts
+++ b/src/features/check-for-updates.ts
@@ -1,7 +1,8 @@
 import * as core from '@actions/core'
-import {toSemVer} from '../utils'
+import {getLatestRelease, toSemVer} from '../utils'
 import {lt, major, minor, valid} from 'semver'
-import {getLatestReleaseVersion} from '../graalvm'
+import {findGraalVMVersion} from '../graalvm'
+import {GRAALVM_RELEASES_REPO} from '../constants'
 
 export async function checkForUpdates(
   graalVMVersion: string,
@@ -13,7 +14,9 @@ export async function checkForUpdates(
     )
     return
   }
-  const latestGraalVMVersion = await getLatestReleaseVersion()
+
+  const latestRelease = await getLatestRelease(GRAALVM_RELEASES_REPO)
+  const latestGraalVMVersion = findGraalVMVersion(latestRelease)
   const selectedVersion = toSemVer(graalVMVersion)
   const latestVersion = toSemVer(latestGraalVMVersion)
   if (


### PR DESCRIPTION
Allow `java-version: 'dev'` if `version: 'dev'`.

Fixes #30