### PR TITLE
Set default-value for gds-token

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,7 @@ inputs:
   gds-token:
     required: false
     description: 'Download token for the GraalVM Download Service. If provided, the action will set up GraalVM Enterprise Edition.'
+    default: ''
   java-version:
     required: true
     description: 'Java version (11 or 17, 8 or 16 for older releases).'


### PR DESCRIPTION
Hi @fniephaus,

Thanks for your work on GraalVM and on this GitHub action.

I've found the following bug: Currently there is no default value set for 'gds-token'. When I try to use GraalVM CE in this GitHub-action I get the error message 'Bad credentials'. It's not possible to manually set the 'gds-token' to an empty string, because GitHub ignores this.

Solution: Set the default value to an empty string (as described in the readme).

Best wishes!