### PR TITLE
Support new GraalVM for JDK17/JDK20 release.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,13 +20,49 @@ jobs:
           npm install
       - run: |
           npm run all
+  test:
+    name: GraalVM
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        java-version: ['17', '20', 'dev']
+        distribution: ['graalvm', 'graalvm-community']
+        os: [macos-latest, windows-latest, ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run setup-graalvm action
+        uses: ./
+        with:
+          java-version: ${{ matrix.java-version }}
+          distribution: ${{ matrix.distribution }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check environment
+        run: |
+          echo "GRAALVM_HOME: $GRAALVM_HOME"
+          if [[ "${{ matrix.java-version }}" == "dev" ]]; then
+            [[ "$GRAALVM_HOME" == *"$RUNNER_TEMP"* ]] || exit 12
+          else
+            [[ "$GRAALVM_HOME" == *"$RUNNER_TOOL_CACHE"* ]] || exit 23
+          fi
+          echo "JAVA_HOME: $JAVA_HOME"
+          java --version
+          java --version | grep "GraalVM" || exit 34
+          native-image --version
+        if: runner.os != 'Windows'
+      - name: Check Windows environment
+        run: |
+          echo "GRAALVM_HOME: $env:GRAALVM_HOME"
+          echo "JAVA_HOME: $env:JAVA_HOME"
+          java --version
+          native-image --version
   test-ce: # make sure the action works on a clean machine without building
+    needs: test  
     name: CE ${{ matrix.version }} + JDK${{ matrix.java-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         version: ['latest', 'dev']
-        java-version: ['19', '20']
+        java-version: ['17', '20']
         components: ['native-image']
         os: [macos-latest, windows-latest, ubuntu-latest]
         exclude:
@@ -70,7 +106,7 @@ jobs:
           fi
           echo "JAVA_HOME: $JAVA_HOME"
           java --version
-          java --version | grep "GraalVM CE" || exit 34
+          java --version | grep "GraalVM" || exit 34
           native-image --version
           gu list
         if: runner.os != 'Windows'
@@ -83,6 +119,7 @@ jobs:
           gu.cmd remove native-image
         if: runner.os == 'Windows'
   test-ee:
+    needs: test
     name: EE ${{ matrix.version }} + JDK${{ matrix.java-version }} on ${{ matrix.os }}
     if: github.event_name != 'pull_request'
     runs-on: ${{ matrix.os }}
@@ -130,6 +167,7 @@ jobs:
           gu.cmd remove native-image
         if: runner.os == 'Windows'
   test-mandrel:
+    needs: test
     name: ${{ matrix.version }} + JDK${{ matrix.java-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -175,9 +213,8 @@ jobs:
       - name: Run setup-graalvm action
         uses: ./
         with:
-          version: 'dev'
           java-version: 'dev'
-          components: 'native-image'
+          distribution: 'graalvm-community'
           native-image-job-reports: 'true'
           native-image-pr-reports: 'true'
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -188,8 +225,8 @@ jobs:
           native-image HelloWorld
           ./helloworld
   test-native-image-windows-msvc:
-    name: native-image on windows-2019
-    runs-on: windows-2019
+    name: native-image on windows-2022
+    runs-on: windows-2022
     permissions:
       contents: read
       pull-requests: write # for `native-image-pr-reports` option
@@ -198,9 +235,8 @@ jobs:
       - name: Run setup-graalvm action
         uses: ./
         with:
-          version: '22.3.1'
           java-version: '17'
-          components: 'native-image'
+          distribution: 'graalvm'
           native-image-job-reports: 'true'
           native-image-pr-reports: 'true'
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -221,9 +257,8 @@ jobs:
       - name: Run setup-graalvm action
         uses: ./
         with:
-          version: 'dev'
           java-version: 'dev'
-          components: 'native-image'
+          distribution: 'graalvm-community'
           native-image-musl: 'true'
           native-image-job-reports: 'true'
           native-image-pr-reports: 'true'
@@ -245,9 +280,9 @@ jobs:
       - name: Run setup-graalvm action
         uses: ./
         with:
-          version: 'latest'
           java-version: '17'
-          components: 'espresso,llvm-toolchain,native-image,nodejs,python,R,ruby,wasm'
+          distribution: 'graalvm'
+          components: 'espresso,llvm-toolchain,native-image,nodejs,python,ruby,wasm'
           set-java-home: 'false'
           native-image-job-reports: 'true'
           native-image-pr-reports: 'true'
@@ -268,8 +303,6 @@ jobs:
           [[ $(which node) == *"graalvm"* ]] || exit 45
           node --version
           graalpy --version
-          [[ $(which R) == *"graalvm"* ]] || exit 56
-          R --version
           truffleruby --version
           wasm --version
       - name: Build HelloWorld.java with GraalVM Native Image
@@ -290,4 +323,4 @@ jobs:
           bundle exec rake test
           popd > /dev/null
       - name: Remove components
-        run: gu remove espresso llvm-toolchain nodejs python R ruby wasm
+        run: gu remove espresso llvm-toolchain nodejs python ruby wasm

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -137,6 +137,10 @@ jobs:
         version: ['mandrel-22.2.0.0-Final', 'mandrel-latest']
         java-version: ['17']
         os: [windows-latest, ubuntu-latest]
+        exclude: # temporarily disable Mandrel latest builds on Windows due to unavailability
+          - version: 'mandrel-latest'
+            java-version: '17'
+            os: windows-latest
     steps:
       - uses: actions/checkout@v3
       - name: Run setup-graalvm action

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ This action:
 
 ## Migrating from GraalVM 22.3 or earlier to the new GraalVM for JDK 17 and later
 
-The new [GraalVM release](https://medium.com/graalvm/a-new-graalvm-release-and-new-free-license-4aab483692f5) aligns the version scheme with OpenJDK.
-As a result, this action no longer requires the `version` option that was used to select a specific GraalVM version.
-At the same time, it introduces a new `distribution` option that can be used to select a specific GraalVM distribution (`graalvm`, `graalvm-community`, and `mandrel`).
-Therefore, to migrate workflows to use the latest GraalVM release, replace the `version` with the `distribution` option in your workflow `yml` config, for example:
+The new [GraalVM for JDK 17 and JDK 20 release](https://medium.com/graalvm/a-new-graalvm-release-and-new-free-license-4aab483692f5) aligns the GraalVM version scheme with OpenJDK.
+As a result, this action no longer requires the `version` option to select a specific GraalVM version.
+At the same time, it introduces a new `distribution` option to select a specific GraalVM distribution (`graalvm`, `graalvm-community`, or `mandrel`).
+Therefore, to migrate your workflow to use the latest GraalVM release, replace the `version` with the `distribution` option in the workflow `yml` config, for example:
 
 ```yml
 # ...
@@ -31,7 +31,7 @@ Therefore, to migrate workflows to use the latest GraalVM release, replace the `
     # ...
 ```
 
-can be turned into:
+can be replaced with:
 
 ```yml
 # ...
@@ -166,17 +166,17 @@ jobs:
 
 | Name            | Default  | Description |
 |-----------------|:--------:|-------------|
-| `java-version`<br>*(required)* | n/a | `'17.0.7'` or `'20.0.1'` for a specific Java version, `'dev'` for a dev build with the highest Java version available.<br>(`'8'`, `'11'`, `'16'`, `'19'` are supported for older GraalVM releases.) |
+| `java-version`<br>*(required)* | n/a | `'17.0.7'` or `'20.0.1'` for a specific Java version, `'dev'` for a dev build with the latest Java version available.<br>(`'8'`, `'11'`, `'16'`, `'19'` are supported for older GraalVM releases.) |
 | `distribution`  | `''` | GraalVM distribution (`graalvm` for Oracle GraalVM, `graalvm-community` for GraalVM Community Edition, `mandrel` for Mandrel). |
 | `github-token`  | `'${{ github.token }}'` | Token for communication with the GitHub API. Please set this to `${{ secrets.GITHUB_TOKEN }}` (see [templates](#templates)) to allow the action to authenticate with the GitHub API, which helps reduce rate-limiting issues. |
 | `set-java-home` | `'true'` | If set to `'true'`, instructs the action to set `$JAVA_HOME` to the path of the GraalVM installation. Overrides any previous action or command that sets `$JAVA_HOME`. |
-| `cache`         | `''`     | Name of the build platform to cache dependencies. It can be `'maven'`, `'gradle'`, or `'sbt'` and works the same way as described in [actions/setup-java][setup-java-caching]. |
+| `cache`         | `''`     | Name of the build platform to cache dependencies. Turned off by default (`''`). It can also be `'maven'`, `'gradle'`, or `'sbt'` and works the same way as described in [actions/setup-java][setup-java-caching]. |
 | `check-for-updates` | `'true'`  | [Annotate jobs][gha-annotations] with update notifications, for example when a new GraalVM release is available. |
 | `native-image-musl` | `'false'` | If set to `'true'`, sets up [musl] to build [static binaries][native-image-static] with GraalVM Native Image *(Linux only)*. [Example usage][native-image-musl-build] (be sure to replace `uses: ./` with `uses: graalvm/setup-graalvm@v1`). |
 | `native-image-job-reports` *) | `'false'` | If set to `'true'`, post a job summary containing a Native Image build report. |
 | `native-image-pr-reports`  *) | `'false'` | If set to `'true'`, post a comment containing a Native Image build report on pull requests. Requires `write` permissions for the [`pull-requests` scope][gha-permissions]. |
 | `components`    | `''`     | Comma-separated list of GraalVM components (e.g., `native-image` or `ruby,nodejs`) that will be installed by the [GraalVM Updater][gu]. |
-| `version` | n/a | `X.Y.Z` (e.g., `22.3.0`) for a specific [GraalVM release][releases] up to `22.3.2`<br>`mandrel-X.Y.Z` (e.g., `mandrel-21.3.0.0-Final`) for a specific [Mandrel release][mandrel-releases],<br>`mandrel-latest` for [latest Mandrel stable release][mandrel-stable]. |
+| `version` | `''` | `X.Y.Z` (e.g., `22.3.0`) for a specific [GraalVM release][releases] up to `22.3.2`<br>`mandrel-X.Y.Z` (e.g., `mandrel-21.3.0.0-Final`) for a specific [Mandrel release][mandrel-releases],<br>`mandrel-latest` for [latest Mandrel stable release][mandrel-stable]. |
 | `gds-token`     | `''`     | Download token for the GraalVM Download Service. If a non-empty token is provided, the action will set up GraalVM Enterprise Edition (see [GraalVM EE template](#template-for-graalvm-enterprise-edition)). |
 
 **) Make sure that Native Image is used only once per build job. Otherwise, the report is only generated for the last Native Image build.*

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # GitHub Action for GraalVM [![build-test](https://github.com/graalvm/setup-graalvm/actions/workflows/test.yml/badge.svg)](https://github.com/graalvm/setup-graalvm/actions/workflows/test.yml)
-This GitHub action sets up [Oracle GraalVM][graalvm], GraalVM [Community Edition (CE)][repo], [Enterprise Edition (EE)][graalvm-ee], or [Mandrel][mandrel], as well as [Native Image][native-image] and GraalVM components such as [Truffle languages][truffle-languages].
+This GitHub action sets up [Oracle GraalVM][graalvm-medium], GraalVM [Community Edition (CE)][repo], [Enterprise Edition (EE)][graalvm-ee], or [Mandrel][mandrel], as well as [Native Image][native-image] and GraalVM components such as [Truffle languages][truffle-languages].
 
 ## Key Features
 
@@ -15,7 +15,7 @@ This action:
 - has built-in support for GraalVM components and the [GraalVM Updater][gu]
 
 
-## Migrating from GraalVM 22.3 or earlier to the new GraalVM for JDK 17 and later
+## Migrating from GraalVM 22.3 or Earlier to the New GraalVM for JDK 17 and Later
 
 The new [GraalVM for JDK 17 and JDK 20 release](https://medium.com/graalvm/a-new-graalvm-release-and-new-free-license-4aab483692f5) aligns the GraalVM version scheme with OpenJDK.
 As a result, this action no longer requires the `version` option to select a specific GraalVM version.
@@ -198,6 +198,7 @@ Only pull requests from committers that can be verified as having signed the OCA
 [gu]: https://www.graalvm.org/reference-manual/graalvm-updater/
 [graalvm]: https://www.graalvm.org/
 [graalvm-dl]: https://www.oracle.com/java/technologies/downloads/
+[graalvm-medium]: https://medium.com/graalvm/a-new-graalvm-release-and-new-free-license-4aab483692f5
 [graalvm-ee]: https://www.oracle.com/downloads/graalvm-downloads.html
 [mandrel]: https://github.com/graalvm/mandrel
 [mandrel-releases]: https://github.com/graalvm/mandrel/releases

--- a/__tests__/gds.test.ts
+++ b/__tests__/gds.test.ts
@@ -1,5 +1,5 @@
 import * as path from 'path'
-import {downloadGraalVMEE, fetchArtifact} from '../src/gds'
+import {downloadGraalVMEELegacy, fetchArtifact} from '../src/gds'
 import {expect, test} from '@jest/globals'
 
 const TEST_USER_AGENT = 'GraalVMGitHubActionTest/1.0.4'
@@ -32,13 +32,15 @@ test('fetch artifacts', async () => {
 })
 
 test('errors when downloading artifacts', async () => {
-  await expect(downloadGraalVMEE('invalid', '22.1.0', '11')).rejects.toThrow(
+  await expect(
+    downloadGraalVMEELegacy('invalid', '22.1.0', '11')
+  ).rejects.toThrow(
     'The provided "gds-token" was rejected (reason: "Invalid download token", opc-request-id: /'
   )
-  await expect(downloadGraalVMEE('invalid', '1.0.0', '11')).rejects.toThrow(
-    'Unable to find JDK11-based GraalVM EE 1.0.0'
-  )
-  await expect(downloadGraalVMEE('invalid', '22.1.0', '1')).rejects.toThrow(
-    'Unable to find JDK1-based GraalVM EE 22.1.0'
-  )
+  await expect(
+    downloadGraalVMEELegacy('invalid', '1.0.0', '11')
+  ).rejects.toThrow('Unable to find JDK11-based GraalVM EE 1.0.0')
+  await expect(
+    downloadGraalVMEELegacy('invalid', '22.1.0', '1')
+  ).rejects.toThrow('Unable to find JDK1-based GraalVM EE 22.1.0')
 })

--- a/__tests__/graalvm.test.ts
+++ b/__tests__/graalvm.test.ts
@@ -19,7 +19,7 @@ test('request invalid version/javaVersion', async () => {
       await graalvm.setUpGraalVMRelease('', combination[0], combination[1])
     } catch (err) {
       if (!(err instanceof Error)) {
-        fail(`Unexpected non-Erro: ${err}`)
+        fail(`Unexpected non-Error: ${err}`)
       }
       error = err
     }
@@ -31,6 +31,23 @@ test('request invalid version/javaVersion', async () => {
 })
 
 test('find version/javaVersion', async () => {
+  // Make sure the action can find the latest Java version for known major versions
+  for (var majorJavaVersion of ['17', '20']) {
+    await graalvm.findLatestGraalVMJDKCEJavaVersion(majorJavaVersion)
+  }
+
+  let error = new Error('unexpected')
+  try {
+    await graalvm.findLatestGraalVMJDKCEJavaVersion('11')
+    fail('Should not find Java version for 11')
+  } catch (err) {
+    if (!(err instanceof Error)) {
+      fail(`Unexpected non-Error: ${err}`)
+    }
+    error = err
+  }
+  expect(error.message).toContain('Unable to find the latest Java version for')
+
   const latestRelease = await getTaggedRelease(
     GRAALVM_RELEASES_REPO,
     'vm-22.3.1'
@@ -40,7 +57,7 @@ test('find version/javaVersion', async () => {
   const latestJavaVersion = findHighestJavaVersion(latestRelease, latestVersion)
   expect(latestJavaVersion).not.toBe('')
 
-  let error = new Error('unexpected')
+  error = new Error('unexpected')
   try {
     const invalidRelease = {...latestRelease, tag_name: 'invalid'}
     findGraalVMVersion(invalidRelease)
@@ -56,7 +73,7 @@ test('find version/javaVersion', async () => {
     findHighestJavaVersion(latestRelease, 'invalid')
   } catch (err) {
     if (!(err instanceof Error)) {
-      fail(`Unexpected non-Erro: ${err}`)
+      fail(`Unexpected non-Error: ${err}`)
     }
     error = err
   }

--- a/action.yml
+++ b/action.yml
@@ -1,19 +1,17 @@
 name: 'GitHub Action for GraalVM'
-description: 'Set up a specific version of GraalVM Community Edition (CE) or Enterprise Edition (EE)'
+description: 'Set up a specific version of the GraalVM JDK and add the command-line tools to the PATH'
 author: 'GraalVM Community'
 branding:
   icon: 'terminal'  
   color: 'blue'
 inputs:
-  version:
-    required: true
-    description: 'GraalVM version (release, latest, dev).'
-  gds-token:
-    required: false
-    description: 'Download token for the GraalVM Download Service. If provided, the action will set up GraalVM Enterprise Edition.'
   java-version:
     required: true
-    description: 'Java version (11 or 17, 8 or 16 for older releases).'
+    description: 'Java version. See examples of supported syntax in the README file.'
+  distribution:
+    description: 'GraalVM distribution. See the list of available distributions in the README file.'
+    required: false
+    default: ''
   components:
     required: false
     description: 'Comma-separated list of GraalVM components to be installed.'
@@ -45,6 +43,13 @@ inputs:
     required: false
     description: 'Post a comment containing a Native Image build report on pull requests.'
     default: 'false'
+  version:
+    required: false
+    description: 'GraalVM version (release, latest, dev).'
+    default: ''
+  gds-token:
+    required: false
+    description: 'Download token for the GraalVM Download Service. If provided, the action will set up GraalVM Enterprise Edition.'
 outputs:
   cache-hit:
     description: 'A boolean value to indicate an exact match was found for the primary key'

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -69858,10 +69858,11 @@ else {
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.EVENT_NAME_PULL_REQUEST = exports.ENV_GITHUB_EVENT_NAME = exports.GDS_GRAALVM_PRODUCT_ID = exports.GDS_BASE = exports.MANDREL_NAMESPACE = exports.JDK_HOME_SUFFIX = exports.GRAALVM_RELEASES_REPO = exports.GRAALVM_PLATFORM = exports.GRAALVM_GH_USER = exports.GRAALVM_FILE_EXTENSION = exports.GRAALVM_ARCH = exports.VERSION_LATEST = exports.VERSION_DEV = exports.IS_WINDOWS = exports.IS_MACOS = exports.IS_LINUX = exports.INPUT_NI_MUSL = exports.INPUT_CHECK_FOR_UPDATES = exports.INPUT_CACHE = exports.INPUT_SET_JAVA_HOME = exports.INPUT_GITHUB_TOKEN = exports.INPUT_COMPONENTS = exports.INPUT_JAVA_VERSION = exports.INPUT_GDS_TOKEN = exports.INPUT_VERSION = void 0;
+exports.ERROR_HINT = exports.EVENT_NAME_PULL_REQUEST = exports.ENV_GITHUB_EVENT_NAME = exports.GDS_GRAALVM_PRODUCT_ID = exports.GDS_BASE = exports.MANDREL_NAMESPACE = exports.GRAALVM_RELEASES_REPO = exports.GRAALVM_PLATFORM = exports.GRAALVM_GH_USER = exports.GRAALVM_FILE_EXTENSION = exports.GRAALVM_ARCH = exports.JDK_HOME_SUFFIX = exports.JDK_PLATFORM = exports.JDK_ARCH = exports.VERSION_LATEST = exports.VERSION_DEV = exports.DISTRIBUTION_MANDREL = exports.DISTRIBUTION_GRAALVM_COMMUNITY = exports.DISTRIBUTION_GRAALVM = exports.IS_WINDOWS = exports.IS_MACOS = exports.IS_LINUX = exports.INPUT_NI_MUSL = exports.INPUT_CHECK_FOR_UPDATES = exports.INPUT_CACHE = exports.INPUT_SET_JAVA_HOME = exports.INPUT_GITHUB_TOKEN = exports.INPUT_COMPONENTS = exports.INPUT_DISTRIBUTION = exports.INPUT_JAVA_VERSION = exports.INPUT_GDS_TOKEN = exports.INPUT_VERSION = void 0;
 exports.INPUT_VERSION = 'version';
 exports.INPUT_GDS_TOKEN = 'gds-token';
 exports.INPUT_JAVA_VERSION = 'java-version';
+exports.INPUT_DISTRIBUTION = 'distribution';
 exports.INPUT_COMPONENTS = 'components';
 exports.INPUT_GITHUB_TOKEN = 'github-token';
 exports.INPUT_SET_JAVA_HOME = 'set-java-home';
@@ -69871,19 +69872,54 @@ exports.INPUT_NI_MUSL = 'native-image-musl';
 exports.IS_LINUX = process.platform === 'linux';
 exports.IS_MACOS = process.platform === 'darwin';
 exports.IS_WINDOWS = process.platform === 'win32';
+exports.DISTRIBUTION_GRAALVM = 'graalvm';
+exports.DISTRIBUTION_GRAALVM_COMMUNITY = 'graalvm-community';
+exports.DISTRIBUTION_MANDREL = 'mandrel';
 exports.VERSION_DEV = 'dev';
 exports.VERSION_LATEST = 'latest';
+exports.JDK_ARCH = determineJDKArchitecture();
+exports.JDK_PLATFORM = determineJDKPlatform();
+exports.JDK_HOME_SUFFIX = exports.IS_MACOS ? '/Contents/Home' : '';
 exports.GRAALVM_ARCH = determineGraalVMArchitecture();
 exports.GRAALVM_FILE_EXTENSION = exports.IS_WINDOWS ? '.zip' : '.tar.gz';
 exports.GRAALVM_GH_USER = 'graalvm';
 exports.GRAALVM_PLATFORM = exports.IS_WINDOWS ? 'windows' : process.platform;
 exports.GRAALVM_RELEASES_REPO = 'graalvm-ce-builds';
-exports.JDK_HOME_SUFFIX = exports.IS_MACOS ? '/Contents/Home' : '';
 exports.MANDREL_NAMESPACE = 'mandrel-';
 exports.GDS_BASE = 'https://gds.oracle.com/api/20220101';
 exports.GDS_GRAALVM_PRODUCT_ID = 'D53FAE8052773FFAE0530F15000AA6C6';
 exports.ENV_GITHUB_EVENT_NAME = 'GITHUB_EVENT_NAME';
 exports.EVENT_NAME_PULL_REQUEST = 'pull_request';
+exports.ERROR_HINT = 'If you think this is a mistake, please file an issue at: https://github.com/graalvm/setup-graalvm/issues.';
+function determineJDKArchitecture() {
+    switch (process.arch) {
+        case 'x64': {
+            return 'x64';
+        }
+        case 'arm64': {
+            return 'aarch64';
+        }
+        default: {
+            throw new Error(`Unsupported architecture: ${process.arch}`);
+        }
+    }
+}
+function determineJDKPlatform() {
+    switch (process.platform) {
+        case 'linux': {
+            return 'linux';
+        }
+        case 'darwin': {
+            return 'macos';
+        }
+        case 'win32': {
+            return 'windows';
+        }
+        default: {
+            throw new Error(`Unsupported platform: ${process.platform}`);
+        }
+    }
+}
 function determineGraalVMArchitecture() {
     switch (process.arch) {
         case 'x64': {
@@ -70193,6 +70229,7 @@ function setUpNativeImageBuildReports(graalVMVersion) {
         }
         const isSupported = graalVMVersion === c.VERSION_LATEST ||
             graalVMVersion === c.VERSION_DEV ||
+            graalVMVersion.length === 0 ||
             (!graalVMVersion.startsWith(c.MANDREL_NAMESPACE) &&
                 (0, semver_1.gte)((0, utils_1.toSemVer)(graalVMVersion), '22.2.0'));
         if (!isSupported) {
@@ -70461,7 +70498,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.createPRComment = exports.isPREvent = exports.toSemVer = exports.calculateSHA256 = exports.downloadExtractAndCacheJDK = exports.downloadAndExtractJDK = exports.getTaggedRelease = exports.getLatestRelease = exports.exec = void 0;
+exports.createPRComment = exports.isPREvent = exports.toSemVer = exports.calculateSHA256 = exports.downloadExtractAndCacheJDK = exports.downloadAndExtractJDK = exports.getMatchingTags = exports.getTaggedRelease = exports.getLatestRelease = exports.exec = void 0;
 const c = __importStar(__nccwpck_require__(9042));
 const core = __importStar(__nccwpck_require__(2186));
 const github = __importStar(__nccwpck_require__(5438));
@@ -70516,6 +70553,19 @@ function getTaggedRelease(repo, tag) {
     });
 }
 exports.getTaggedRelease = getTaggedRelease;
+function getMatchingTags(tagPrefix) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const githubToken = getGitHubToken();
+        const options = githubToken.length > 0 ? { auth: githubToken } : {};
+        const octokit = new GitHubDotCom(options);
+        return (yield octokit.request('GET /repos/{owner}/{repo}/git/matching-refs/tags/{tagPrefix}', {
+            owner: c.GRAALVM_GH_USER,
+            repo: c.GRAALVM_RELEASES_REPO,
+            tagPrefix
+        })).data;
+    });
+}
+exports.getMatchingTags = getMatchingTags;
 function downloadAndExtractJDK(downloadUrl) {
     return __awaiter(this, void 0, void 0, function* () {
         return findJavaHomeInSubfolder(yield extract(yield tc.downloadTool(downloadUrl)));

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -71150,7 +71150,7 @@ function run() {
                         throw new Error(`Mandrel requires the 'version' option (see https://github.com/graalvm/setup-graalvm/tree/main#options).`);
                     case '':
                         if (javaVersion === c.VERSION_DEV) {
-                            core.info(`This build is using the GraalVM Community Edition. To select a specific distribution, use the 'distribution' option (see https://github.com/graalvm/setup-graalvm/tree/main#options).`);
+                            core.info(`This build is using GraalVM Community Edition. To select a specific distribution, use the 'distribution' option (see https://github.com/graalvm/setup-graalvm/tree/main#options).`);
                             graalVMHome = yield graalvm.setUpGraalVMJDKDevBuild();
                         }
                         else {

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -70176,7 +70176,7 @@ function checkForUpdates(graalVMVersion, javaVersion) {
         if (graalVMVersion.length > 0 &&
             (javaVersion === '17' || javaVersion === '19')) {
             const recommendedJDK = javaVersion === '17' ? '17' : '20';
-            core.notice(`A new GraalVM release is available! Please consider upgrading to GraalVM for JDK ${recommendedJDK}. Release notes: https://www.graalvm.org/release-notes/JDK_${recommendedJDK}/`);
+            core.notice(`A new GraalVM release is available! Please consider upgrading to GraalVM for JDK ${recommendedJDK}. Instructions: https://github.com/graalvm/setup-graalvm#migrating-from-graalvm-223-or-earlier-to-the-new-graalvm-for-jdk-17-and-later`);
             return;
         }
         if (graalVMVersion.startsWith('22.3.') && javaVersion === '11') {
@@ -70871,7 +70871,8 @@ function findLatestGraalVMJDKCEJavaVersion(majorJavaVersion) {
         const versionNumberStartIndex = `refs/tags/${GRAALVM_JDK_TAG_PREFIX}`.length;
         for (const matchingRef of matchingRefs) {
             const currentVersion = matchingRef.ref.substring(versionNumberStartIndex);
-            if ((0, semver_1.gt)(currentVersion, highestVersion)) {
+            if ((0, semver_1.valid)(currentVersion) &&
+                (0, semver_1.gt)(currentVersion, highestVersion)) {
                 highestVersion = currentVersion;
             }
         }
@@ -71102,6 +71103,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 const c = __importStar(__nccwpck_require__(9042));
 const core = __importStar(__nccwpck_require__(2186));
 const graalvm = __importStar(__nccwpck_require__(5254));
+const semver_1 = __nccwpck_require__(1383);
 const cache_1 = __nccwpck_require__(7799);
 const path_1 = __nccwpck_require__(1017);
 const cache_2 = __nccwpck_require__(9179);
@@ -71162,7 +71164,8 @@ function run() {
             else {
                 switch (graalvmVersion) {
                     case c.VERSION_LATEST:
-                        if (javaVersion.startsWith('17') || javaVersion.startsWith('20')) {
+                        if (javaVersion.startsWith('17') ||
+                            ((0, semver_1.valid)(javaVersion) && (0, semver_1.gte)(javaVersion, '20'))) {
                             core.info(`This build is using the new Oracle GraalVM. To select a specific distribution, use the 'distribution' option (see https://github.com/graalvm/setup-graalvm/tree/main#options).`);
                             graalVMHome = yield graalvm.setUpGraalVMJDK(javaVersion);
                         }

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -70631,7 +70631,7 @@ const assert_1 = __nccwpck_require__(9491);
 const uuid_1 = __nccwpck_require__(5840);
 function downloadGraalVMEELegacy(gdsToken, version, javaVersion) {
     return __awaiter(this, void 0, void 0, function* () {
-        const userAgent = `GraalVMGitHubAction/1.0.12 (arch:${c.GRAALVM_ARCH}; os:${c.GRAALVM_PLATFORM}; java:${javaVersion})`;
+        const userAgent = `GraalVMGitHubAction/1.1.0 (arch:${c.GRAALVM_ARCH}; os:${c.GRAALVM_PLATFORM}; java:${javaVersion})`;
         const baseArtifact = yield fetchArtifact(userAgent, 'isBase:True', version, javaVersion);
         return downloadArtifact(gdsToken, userAgent, baseArtifact);
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "setup-graalvm",
-  "version": "1.0.12",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "setup-graalvm",
-      "version": "1.0.12",
+      "version": "1.1.0",
       "license": "UPL",
       "dependencies": {
         "@actions/cache": "^3.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-graalvm",
-  "version": "1.0.12",
+  "version": "1.1.0",
   "private": true,
   "description": "GitHub Action for GraalVM",
   "main": "lib/main.js",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,6 +3,7 @@ import * as otypes from '@octokit/types'
 export const INPUT_VERSION = 'version'
 export const INPUT_GDS_TOKEN = 'gds-token'
 export const INPUT_JAVA_VERSION = 'java-version'
+export const INPUT_DISTRIBUTION = 'distribution'
 export const INPUT_COMPONENTS = 'components'
 export const INPUT_GITHUB_TOKEN = 'github-token'
 export const INPUT_SET_JAVA_HOME = 'set-java-home'
@@ -14,15 +15,22 @@ export const IS_LINUX = process.platform === 'linux'
 export const IS_MACOS = process.platform === 'darwin'
 export const IS_WINDOWS = process.platform === 'win32'
 
+export const DISTRIBUTION_GRAALVM = 'graalvm'
+export const DISTRIBUTION_GRAALVM_COMMUNITY = 'graalvm-community'
+export const DISTRIBUTION_MANDREL = 'mandrel'
+
 export const VERSION_DEV = 'dev'
 export const VERSION_LATEST = 'latest'
+
+export const JDK_ARCH = determineJDKArchitecture()
+export const JDK_PLATFORM = determineJDKPlatform()
+export const JDK_HOME_SUFFIX = IS_MACOS ? '/Contents/Home' : ''
 
 export const GRAALVM_ARCH = determineGraalVMArchitecture()
 export const GRAALVM_FILE_EXTENSION = IS_WINDOWS ? '.zip' : '.tar.gz'
 export const GRAALVM_GH_USER = 'graalvm'
 export const GRAALVM_PLATFORM = IS_WINDOWS ? 'windows' : process.platform
 export const GRAALVM_RELEASES_REPO = 'graalvm-ce-builds'
-export const JDK_HOME_SUFFIX = IS_MACOS ? '/Contents/Home' : ''
 
 export const MANDREL_NAMESPACE = 'mandrel-'
 
@@ -32,8 +40,45 @@ export const GDS_GRAALVM_PRODUCT_ID = 'D53FAE8052773FFAE0530F15000AA6C6'
 export const ENV_GITHUB_EVENT_NAME = 'GITHUB_EVENT_NAME'
 export const EVENT_NAME_PULL_REQUEST = 'pull_request'
 
+export const ERROR_HINT =
+  'If you think this is a mistake, please file an issue at: https://github.com/graalvm/setup-graalvm/issues.'
+
 export type LatestReleaseResponse =
   otypes.Endpoints['GET /repos/{owner}/{repo}/releases/latest']['response']
+
+export type MatchingRefsResponse =
+  otypes.Endpoints['GET /repos/{owner}/{repo}/git/matching-refs/{ref}']['response']
+
+function determineJDKArchitecture(): string {
+  switch (process.arch) {
+    case 'x64': {
+      return 'x64'
+    }
+    case 'arm64': {
+      return 'aarch64'
+    }
+    default: {
+      throw new Error(`Unsupported architecture: ${process.arch}`)
+    }
+  }
+}
+
+function determineJDKPlatform(): string {
+  switch (process.platform) {
+    case 'linux': {
+      return 'linux'
+    }
+    case 'darwin': {
+      return 'macos'
+    }
+    case 'win32': {
+      return 'windows'
+    }
+    default: {
+      throw new Error(`Unsupported platform: ${process.platform}`)
+    }
+  }
+}
 
 function determineGraalVMArchitecture(): string {
   switch (process.arch) {

--- a/src/features/check-for-updates.ts
+++ b/src/features/check-for-updates.ts
@@ -8,6 +8,17 @@ export async function checkForUpdates(
   graalVMVersion: string,
   javaVersion: string
 ): Promise<void> {
+  if (
+    graalVMVersion.length > 0 &&
+    (javaVersion === '17' || javaVersion === '19')
+  ) {
+    const recommendedJDK = javaVersion === '17' ? '17' : '20'
+    core.notice(
+      `A new GraalVM release is available! Please consider upgrading to GraalVM for JDK ${recommendedJDK}. Release notes: https://www.graalvm.org/release-notes/JDK_${recommendedJDK}/`
+    )
+    return
+  }
+
   if (graalVMVersion.startsWith('22.3.') && javaVersion === '11') {
     core.notice(
       'Please consider upgrading your project to Java 17+. GraalVM 22.3.X releases are the last to support JDK11: https://github.com/oracle/graal/issues/5063'

--- a/src/features/check-for-updates.ts
+++ b/src/features/check-for-updates.ts
@@ -14,7 +14,7 @@ export async function checkForUpdates(
   ) {
     const recommendedJDK = javaVersion === '17' ? '17' : '20'
     core.notice(
-      `A new GraalVM release is available! Please consider upgrading to GraalVM for JDK ${recommendedJDK}. Release notes: https://www.graalvm.org/release-notes/JDK_${recommendedJDK}/`
+      `A new GraalVM release is available! Please consider upgrading to GraalVM for JDK ${recommendedJDK}. Instructions: https://github.com/graalvm/setup-graalvm#migrating-from-graalvm-223-or-earlier-to-the-new-graalvm-for-jdk-17-and-later`
     )
     return
   }

--- a/src/features/reports.ts
+++ b/src/features/reports.ts
@@ -88,6 +88,7 @@ export async function setUpNativeImageBuildReports(
   const isSupported =
     graalVMVersion === c.VERSION_LATEST ||
     graalVMVersion === c.VERSION_DEV ||
+    graalVMVersion.length === 0 ||
     (!graalVMVersion.startsWith(c.MANDREL_NAMESPACE) &&
       gte(toSemVer(graalVMVersion), '22.2.0'))
   if (!isSupported) {

--- a/src/gds.ts
+++ b/src/gds.ts
@@ -32,7 +32,7 @@ export async function downloadGraalVMEELegacy(
   version: string,
   javaVersion: string
 ): Promise<string> {
-  const userAgent = `GraalVMGitHubAction/1.0.12 (arch:${c.GRAALVM_ARCH}; os:${c.GRAALVM_PLATFORM}; java:${javaVersion})`
+  const userAgent = `GraalVMGitHubAction/1.1.0 (arch:${c.GRAALVM_ARCH}; os:${c.GRAALVM_PLATFORM}; java:${javaVersion})`
   const baseArtifact = await fetchArtifact(
     userAgent,
     'isBase:True',

--- a/src/gds.ts
+++ b/src/gds.ts
@@ -27,7 +27,7 @@ interface GDSErrorResponse {
   readonly message: string
 }
 
-export async function downloadGraalVMEE(
+export async function downloadGraalVMEELegacy(
   gdsToken: string,
   version: string,
   javaVersion: string

--- a/src/graalvm.ts
+++ b/src/graalvm.ts
@@ -9,7 +9,7 @@ import {
 import {downloadGraalVMEELegacy} from './gds'
 import {downloadTool} from '@actions/tool-cache'
 import {basename} from 'path'
-import {gt} from 'semver'
+import {gt as semverGt, valid as semverValid} from 'semver'
 
 const GRAALVM_DL_BASE = 'https://download.oracle.com/graalvm'
 const GRAALVM_CE_DL_BASE = `https://github.com/graalvm/${c.GRAALVM_RELEASES_REPO}/releases/download`
@@ -70,7 +70,10 @@ export async function findLatestGraalVMJDKCEJavaVersion(
   const versionNumberStartIndex = `refs/tags/${GRAALVM_JDK_TAG_PREFIX}`.length
   for (const matchingRef of matchingRefs) {
     const currentVersion = matchingRef.ref.substring(versionNumberStartIndex)
-    if (gt(currentVersion, highestVersion)) {
+    if (
+      semverValid(currentVersion) &&
+      semverGt(currentVersion, highestVersion)
+    ) {
       highestVersion = currentVersion
     }
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import * as c from './constants'
 import * as core from '@actions/core'
 import * as graalvm from './graalvm'
+import {gte as semverGte, valid as semverValid} from 'semver'
 import {isFeatureAvailable as isCacheAvailable} from '@actions/cache'
 import {join} from 'path'
 import {restore} from './features/cache'
@@ -69,7 +70,10 @@ async function run(): Promise<void> {
     } else {
       switch (graalvmVersion) {
         case c.VERSION_LATEST:
-          if (javaVersion.startsWith('17') || javaVersion.startsWith('20')) {
+          if (
+            javaVersion.startsWith('17') ||
+            (semverValid(javaVersion) && semverGte(javaVersion, '20'))
+          ) {
             core.info(
               `This build is using the new Oracle GraalVM. To select a specific distribution, use the 'distribution' option (see https://github.com/graalvm/setup-graalvm/tree/main#options).`
             )

--- a/src/main.ts
+++ b/src/main.ts
@@ -55,7 +55,7 @@ async function run(): Promise<void> {
         case '':
           if (javaVersion === c.VERSION_DEV) {
             core.info(
-              `This build is using the GraalVM Community Edition. To select a specific distribution, use the 'distribution' option (see https://github.com/graalvm/setup-graalvm/tree/main#options).`
+              `This build is using GraalVM Community Edition. To select a specific distribution, use the 'distribution' option (see https://github.com/graalvm/setup-graalvm/tree/main#options).`
             )
             graalVMHome = await graalvm.setUpGraalVMJDKDevBuild()
           } else {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -63,6 +63,24 @@ export async function getTaggedRelease(
   ).data
 }
 
+export async function getMatchingTags(
+  tagPrefix: string
+): Promise<c.MatchingRefsResponse['data']> {
+  const githubToken = getGitHubToken()
+  const options = githubToken.length > 0 ? {auth: githubToken} : {}
+  const octokit = new GitHubDotCom(options)
+  return (
+    await octokit.request(
+      'GET /repos/{owner}/{repo}/git/matching-refs/tags/{tagPrefix}',
+      {
+        owner: c.GRAALVM_GH_USER,
+        repo: c.GRAALVM_RELEASES_REPO,
+        tagPrefix
+      }
+    )
+  ).data
+}
+
 export async function downloadAndExtractJDK(
   downloadUrl: string
 ): Promise<string> {


### PR DESCRIPTION
This PR adds support for the new GraalVM for JDK17/JDK20 release, including the new Oracle GraalVM distribution.
For this, users only need to specify the 'java-version' option and the new 'distribution' option.
The 'version' option is now marked as optional and kept for compatibility with older GraalVM releases and Mandrel.

Closes #45