### PR TITLE
Use DISCO APi for getting latest Mandrel releases

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -187,7 +187,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        version: ['mandrel-22.2.0.0-Final', 'mandrel-latest']
+        version: ['mandrel-22.2.0.0-Final', '23.0.1.2-Final', 'mandrel-latest']
         java-version: ['17']
         distribution: ['mandrel']
         os: [windows-latest, ubuntu-latest]
@@ -196,10 +196,6 @@ jobs:
             java-version: '17'
             distribution: '' # test empty distribution for backward compatibility
             os: ubuntu-latest
-        exclude: # temporarily disable Mandrel latest builds on Windows due to unavailability
-          - version: 'mandrel-latest'
-            java-version: '17'
-            os: windows-latest
     steps:
       - uses: actions/checkout@v4
       - name: Run setup-graalvm action

--- a/__tests__/mandrel.test.ts
+++ b/__tests__/mandrel.test.ts
@@ -1,0 +1,56 @@
+import * as path from 'path'
+import * as mandrel from '../src/mandrel'
+import {expect, test} from '@jest/globals'
+import {getLatestRelease} from '../src/utils'
+
+process.env['RUNNER_TOOL_CACHE'] = path.join(__dirname, 'TOOL_CACHE')
+process.env['RUNNER_TEMP'] = path.join(__dirname, 'TEMP')
+
+test('request invalid version/javaVersion combination', async () => {
+  for (var combination of [
+    ['mandrel-23.1.1.0-Final', '17'],
+    ['mandrel-23.0.2.1-Final', '21'],
+  ]) {
+    let error = new Error('unexpected')
+    try {
+      await mandrel.setUpMandrel(combination[0], combination[1])
+    } catch (err) {
+      if (!(err instanceof Error)) {
+        fail(`Unexpected non-Error: ${err}`)
+      }
+      error = err
+    }
+
+    expect(error).not.toBeUndefined()
+    expect(error.message).toContain('Failed to download')
+    expect(error.message).toContain('Are you sure version')
+  }
+})
+test('request invalid version', async () => {
+  for (var combination of [
+    ['mandrel-23.1.1.0', '21'],
+    ['mandrel-23.0.2.1', '17'],
+  ]) {
+    let error = new Error('unexpected')
+    try {
+      await mandrel.setUpMandrel(combination[0], combination[1])
+    } catch (err) {
+      if (!(err instanceof Error)) {
+        fail(`Unexpected non-Error: ${err}`)
+      }
+      error = err
+    }
+
+    expect(error).not.toBeUndefined()
+    expect(error.message).toContain('Failed to download')
+    expect(error.message).toContain('Are you sure version')
+  }
+})
+
+test('find latest', async () => {
+  // Make sure the action can find the latest Mandrel release
+  const latestRelease = await getLatestRelease(mandrel.MANDREL_REPO)
+  const tag_name = latestRelease.tag_name
+  expect(tag_name).toContain(mandrel.MANDREL_TAG_PREFIX)
+})
+

--- a/__tests__/mandrel.test.ts
+++ b/__tests__/mandrel.test.ts
@@ -9,7 +9,7 @@ process.env['RUNNER_TEMP'] = path.join(__dirname, 'TEMP')
 test('request invalid version/javaVersion combination', async () => {
   for (var combination of [
     ['mandrel-23.1.1.0-Final', '17'],
-    ['mandrel-23.0.2.1-Final', '21'],
+    ['mandrel-23.0.2.1-Final', '21']
   ]) {
     let error = new Error('unexpected')
     try {
@@ -29,7 +29,7 @@ test('request invalid version/javaVersion combination', async () => {
 test('request invalid version', async () => {
   for (var combination of [
     ['mandrel-23.1.1.0', '21'],
-    ['mandrel-23.0.2.1', '17'],
+    ['mandrel-23.0.2.1', '17']
   ]) {
     let error = new Error('unexpected')
     try {
@@ -54,15 +54,19 @@ test('find latest', async () => {
   expect(tag_name).toContain(mandrel.MANDREL_TAG_PREFIX)
 })
 
-test('get latest Mandrel for specific JDK', async () => {
+test('get known latest Mandrel for specific JDK', async () => {
   // Test deprecated versions that won't get updates anymore
   for (var combination of [
     ['11', '22.2.0.0-Final'],
-    ['20', '23.0.1.2-Final']]) {
+    ['20', '23.0.1.2-Final']
+  ]) {
     const latest = await mandrel.getLatestMandrelReleaseUrl(combination[0])
     expect(latest).toContain(`mandrel-java${combination[0]}`)
     expect(latest).toContain(combination[1])
   }
+})
+
+test('get latest Mandrel for specific JDK', async () => {
   // Test supported versions
   for (var javaVersion of ['17', '21']) {
     const latest = await mandrel.getLatestMandrelReleaseUrl(javaVersion)

--- a/__tests__/mandrel.test.ts
+++ b/__tests__/mandrel.test.ts
@@ -54,3 +54,19 @@ test('find latest', async () => {
   expect(tag_name).toContain(mandrel.MANDREL_TAG_PREFIX)
 })
 
+test('get latest Mandrel for specific JDK', async () => {
+  // Test deprecated versions that won't get updates anymore
+  for (var combination of [
+    ['11', '22.2.0.0-Final'],
+    ['20', '23.0.1.2-Final']]) {
+    const latest = await mandrel.getLatestMandrelReleaseUrl(combination[0])
+    expect(latest).toContain(`mandrel-java${combination[0]}`)
+    expect(latest).toContain(combination[1])
+  }
+  // Test supported versions
+  for (var javaVersion of ['17', '21']) {
+    const latest = await mandrel.getLatestMandrelReleaseUrl(javaVersion)
+    expect(latest).toContain(`mandrel-java${javaVersion}`)
+  }
+})
+

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -58304,7 +58304,7 @@ class Range {
     this.set = this.raw
       .split('||')
       // map the range to a 2d array of comparators
-      .map(r => this.parseRange(r.trim()))
+      .map(r => this.parseRange(r))
       // throw out any comparator lists that are empty
       // this generally means that it was not a valid range, which is allowed
       // in loose mode, but will still throw if the WHOLE range is invalid.
@@ -58364,18 +58364,15 @@ class Range {
     const hr = loose ? re[t.HYPHENRANGELOOSE] : re[t.HYPHENRANGE]
     range = range.replace(hr, hyphenReplace(this.options.includePrerelease))
     debug('hyphen replace', range)
-
     // `> 1.2.3 < 1.2.5` => `>1.2.3 <1.2.5`
     range = range.replace(re[t.COMPARATORTRIM], comparatorTrimReplace)
     debug('comparator trim', range)
 
     // `~ 1.2.3` => `~1.2.3`
     range = range.replace(re[t.TILDETRIM], tildeTrimReplace)
-    debug('tilde trim', range)
 
     // `^ 1.2.3` => `^1.2.3`
     range = range.replace(re[t.CARETTRIM], caretTrimReplace)
-    debug('caret trim', range)
 
     // At this point, the range is completely trimmed and
     // ready to be split into comparators.
@@ -59677,10 +59674,6 @@ const MAX_SAFE_INTEGER = Number.MAX_SAFE_INTEGER ||
 // Max safe segment length for coercion.
 const MAX_SAFE_COMPONENT_LENGTH = 16
 
-// Max safe length for a build identifier. The max length minus 6 characters for
-// the shortest version with a build 0.0.0+BUILD.
-const MAX_SAFE_BUILD_LENGTH = MAX_LENGTH - 6
-
 const RELEASE_TYPES = [
   'major',
   'premajor',
@@ -59694,7 +59687,6 @@ const RELEASE_TYPES = [
 module.exports = {
   MAX_LENGTH,
   MAX_SAFE_COMPONENT_LENGTH,
-  MAX_SAFE_BUILD_LENGTH,
   MAX_SAFE_INTEGER,
   RELEASE_TYPES,
   SEMVER_SPEC_VERSION,
@@ -59776,11 +59768,7 @@ module.exports = parseOptions
 /***/ 9523:
 /***/ ((module, exports, __nccwpck_require__) => {
 
-const {
-  MAX_SAFE_COMPONENT_LENGTH,
-  MAX_SAFE_BUILD_LENGTH,
-  MAX_LENGTH,
-} = __nccwpck_require__(2293)
+const { MAX_SAFE_COMPONENT_LENGTH } = __nccwpck_require__(2293)
 const debug = __nccwpck_require__(427)
 exports = module.exports = {}
 
@@ -59791,31 +59779,16 @@ const src = exports.src = []
 const t = exports.t = {}
 let R = 0
 
-const LETTERDASHNUMBER = '[a-zA-Z0-9-]'
-
-// Replace some greedy regex tokens to prevent regex dos issues. These regex are
-// used internally via the safeRe object since all inputs in this library get
-// normalized first to trim and collapse all extra whitespace. The original
-// regexes are exported for userland consumption and lower level usage. A
-// future breaking change could export the safer regex only with a note that
-// all input should have extra whitespace removed.
-const safeRegexReplacements = [
-  ['\\s', 1],
-  ['\\d', MAX_LENGTH],
-  [LETTERDASHNUMBER, MAX_SAFE_BUILD_LENGTH],
-]
-
-const makeSafeRegex = (value) => {
-  for (const [token, max] of safeRegexReplacements) {
-    value = value
-      .split(`${token}*`).join(`${token}{0,${max}}`)
-      .split(`${token}+`).join(`${token}{1,${max}}`)
-  }
-  return value
-}
-
 const createToken = (name, value, isGlobal) => {
-  const safe = makeSafeRegex(value)
+  // Replace all greedy whitespace to prevent regex dos issues. These regex are
+  // used internally via the safeRe object since all inputs in this library get
+  // normalized first to trim and collapse all extra whitespace. The original
+  // regexes are exported for userland consumption and lower level usage. A
+  // future breaking change could export the safer regex only with a note that
+  // all input should have extra whitespace removed.
+  const safe = value
+    .split('\\s*').join('\\s{0,1}')
+    .split('\\s+').join('\\s')
   const index = R++
   debug(name, index, value)
   t[name] = index
@@ -59831,13 +59804,13 @@ const createToken = (name, value, isGlobal) => {
 // A single `0`, or a non-zero digit followed by zero or more digits.
 
 createToken('NUMERICIDENTIFIER', '0|[1-9]\\d*')
-createToken('NUMERICIDENTIFIERLOOSE', '\\d+')
+createToken('NUMERICIDENTIFIERLOOSE', '[0-9]+')
 
 // ## Non-numeric Identifier
 // Zero or more digits, followed by a letter or hyphen, and then zero or
 // more letters, digits, or hyphens.
 
-createToken('NONNUMERICIDENTIFIER', `\\d*[a-zA-Z-]${LETTERDASHNUMBER}*`)
+createToken('NONNUMERICIDENTIFIER', '\\d*[a-zA-Z-][a-zA-Z0-9-]*')
 
 // ## Main Version
 // Three dot-separated numeric identifiers.
@@ -59872,7 +59845,7 @@ createToken('PRERELEASELOOSE', `(?:-?(${src[t.PRERELEASEIDENTIFIERLOOSE]
 // ## Build Metadata Identifier
 // Any combination of digits, letters, or hyphens.
 
-createToken('BUILDIDENTIFIER', `${LETTERDASHNUMBER}+`)
+createToken('BUILDIDENTIFIER', '[0-9A-Za-z-]+')
 
 // ## Build Metadata
 // Plus sign, followed by one or more period-separated build metadata

--- a/src/main.ts
+++ b/src/main.ts
@@ -58,13 +58,7 @@ async function run(): Promise<void> {
           graalVMHome = await graalvm.setUpGraalVMJDKCE(javaVersion)
           break
         case c.DISTRIBUTION_MANDREL:
-          if (graalVMVersion.startsWith(c.MANDREL_NAMESPACE)) {
-            graalVMHome = await setUpMandrel(graalVMVersion, javaVersion)
-          } else {
-            throw new Error(
-              `Mandrel requires the 'version' option (see https://github.com/graalvm/setup-graalvm/tree/main#options).`
-            )
-          }
+          graalVMHome = await setUpMandrel(graalVMVersion, javaVersion)
           break
         case '':
           if (javaVersion === c.VERSION_DEV) {

--- a/src/mandrel.ts
+++ b/src/mandrel.ts
@@ -6,6 +6,7 @@ import {basename} from 'path'
 export const MANDREL_REPO = 'mandrel'
 export const MANDREL_TAG_PREFIX = c.MANDREL_NAMESPACE
 const MANDREL_DL_BASE = 'https://github.com/graalvm/mandrel/releases/download'
+const DISCO_API_BASE = 'https://api.foojay.io/disco/v3.0/packages/jdks'
 
 export async function setUpMandrel(
   graalvmVersion: string,
@@ -30,16 +31,55 @@ export async function setUpMandrel(
 }
 
 async function setUpMandrelLatest(javaVersion: string): Promise<string> {
-  const latestRelease = await getLatestRelease(MANDREL_REPO)
-  const tag_name = latestRelease.tag_name
-  if (tag_name.startsWith(MANDREL_TAG_PREFIX)) {
-    const latestVersion = tag_name.substring(
-      MANDREL_TAG_PREFIX.length,
-      tag_name.length
-    )
-    return setUpMandrelRelease(latestVersion, javaVersion)
+  const latest_release_url = await getLatestMandrelReleaseUrl(javaVersion)
+  const version_tag = getTagFromURI(latest_release_url);
+  const version = version_tag.substring(c.MANDREL_NAMESPACE.length, version_tag.length)
+  console.log(version);
+    
+  const toolName = determineToolName(javaVersion)
+  return downloadExtractAndCacheJDK(
+    async () => downloadTool(latest_release_url),
+    toolName,
+    version
+  )
+}
+
+// Download URIs are of the form https://github.com/graalvm/mandrel/releases/download/<tag>/<archive-name>
+function getTagFromURI(uri: string): string {
+  const parts = uri.split('/');
+  try {
+    return parts[parts.length - 2];
+  } catch (error) {
+    throw new Error(`Failed to extract tag from URI ${uri}: ${error}`)
   }
-  throw new Error(`Could not find latest Mandrel release: ${tag_name}`)
+}
+
+export async function getLatestMandrelReleaseUrl(javaVersion: string): Promise<string> {
+  const url = `${DISCO_API_BASE}?jdk_version=${javaVersion}&distribution=${c.DISTRIBUTION_MANDREL}&architecture=${c.JDK_ARCH}&operating_system=${c.JDK_PLATFORM}&latest=per_distro`
+  const response = await fetch(url)
+  if (!response.ok) {
+    throw new Error(`Failed to fetch latest Mandrel release for Java ${javaVersion} from DISCO API: ${response.statusText}`)
+  }
+  const data = await response.json()
+  try {
+    const pkg_info_uri = data.result[0].links.pkg_info_uri
+    return getLatestMandrelReleaseUrlHelper(javaVersion, pkg_info_uri)
+  } catch (error) {
+    throw new Error(`Failed to get latest Mandrel release for Java ${javaVersion} from DISCO API: ${error}`)
+  }
+}
+
+async function getLatestMandrelReleaseUrlHelper(java_version: string, pkg_info_uri: string): Promise<string> {
+  const response = await fetch(pkg_info_uri)
+  if (!response.ok) {
+    throw new Error(`Failed to fetch package info of latest Mandrel release for Java ${java_version} from DISCO API: ${response.statusText}`)
+  }
+  const data = await response.json()
+  try {
+    return data.result[0].direct_download_uri
+  } catch (error) {
+    throw new Error(`Failed to get download URI of latest Mandrel release for Java ${java_version} from DISCO API: ${error}`)
+  }
 }
 
 async function setUpMandrelRelease(


### PR DESCRIPTION
- Improve error log for wrong mandrel version and javaVersion comb.
- Use Foojay.io DISCO API to get latest Mandrel release
- Relax requirement of mandrel versions starting with `mandrel-`
- Restore windows latest test & add test for non-prefixed mandrel ver

Closes https://github.com/graalvm/setup-graalvm/issues/64