### PR TITLE
Get latest mandrel when `version` not specified

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -196,6 +196,10 @@ jobs:
             java-version: '17'
             distribution: '' # test empty distribution for backward compatibility
             os: ubuntu-latest
+          - version: '' # test with no version
+            java-version: '21'
+            distribution: 'mandrel'
+            os: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Run setup-graalvm action

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ jobs:
 | `native-image-job-reports` *) | `'false'` | If set to `'true'`, post a job summary containing a Native Image build report. |
 | `native-image-pr-reports`  *) | `'false'` | If set to `'true'`, post a comment containing a Native Image build report on pull requests. Requires `write` permissions for the [`pull-requests` scope][gha-permissions]. |
 | `components`    | `''`     | Comma-separated list of GraalVM components (e.g., `native-image` or `ruby,nodejs`) that will be installed by the [GraalVM Updater][gu]. |
-| `version` | `''` | `X.Y.Z` (e.g., `22.3.0`) for a specific [GraalVM release][releases] up to `22.3.2`<br>`mandrel-X.Y.Z` (e.g., `mandrel-21.3.0.0-Final`) for a specific [Mandrel release][mandrel-releases],<br>`mandrel-latest` for [latest Mandrel stable release][mandrel-stable]. |
+| `version` | `''` | `X.Y.Z` (e.g., `22.3.0`) for a specific [GraalVM release][releases] up to `22.3.2`<br>`mandrel-X.Y.Z.W` or `X.Y.Z.W-Final` (e.g., `mandrel-21.3.0.0-Final` or `21.3.0.0-Final`) for a specific [Mandrel release][mandrel-releases],<br>`mandrel-latest` or `latest` for the latest Mandrel stable release. |
 | `gds-token`     | `''`     | Download token for the GraalVM Download Service. If a non-empty token is provided, the action will set up GraalVM Enterprise Edition (see [GraalVM EE template](#template-for-graalvm-enterprise-edition)). |
 
 **) Make sure that Native Image is used only once per build job. Otherwise, the report is only generated for the last Native Image build.*

--- a/__tests__/mandrel.test.ts
+++ b/__tests__/mandrel.test.ts
@@ -73,4 +73,3 @@ test('get latest Mandrel for specific JDK', async () => {
     expect(latest).toContain(`mandrel-java${javaVersion}`)
   }
 })
-

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -71524,6 +71524,8 @@ function setUpMandrel(mandrelVersion, javaVersion) {
         const version = stripMandrelNamespace(mandrelVersion);
         let mandrelHome;
         switch (version) {
+            case '':
+            // fetch latest if no version is specified
             case 'latest':
                 mandrelHome = yield setUpMandrelLatest(javaVersion);
                 break;
@@ -71558,7 +71560,7 @@ function getLatestMandrelReleaseUrl(javaVersion) {
     var _a;
     return __awaiter(this, void 0, void 0, function* () {
         const url = `${DISCO_API_BASE}?jdk_version=${javaVersion}&distribution=${c.DISTRIBUTION_MANDREL}&architecture=${c.JDK_ARCH}&operating_system=${c.JDK_PLATFORM}&latest=per_distro`;
-        const _http = new httpClient.HttpClient('http-client-tests');
+        const _http = new httpClient.HttpClient();
         const response = yield _http.getJson(url);
         if (response.statusCode !== 200) {
             throw new Error(`Failed to fetch latest Mandrel release for Java ${javaVersion} from DISCO API: ${response.result}`);

--- a/src/mandrel.ts
+++ b/src/mandrel.ts
@@ -21,6 +21,8 @@ export async function setUpMandrel(
   const version = stripMandrelNamespace(mandrelVersion)
   let mandrelHome
   switch (version) {
+    case '':
+    // fetch latest if no version is specified
     case 'latest':
       mandrelHome = await setUpMandrelLatest(javaVersion)
       break

--- a/src/mandrel.ts
+++ b/src/mandrel.ts
@@ -59,7 +59,7 @@ export async function getLatestMandrelReleaseUrl(
   javaVersion: string
 ): Promise<string> {
   const url = `${DISCO_API_BASE}?jdk_version=${javaVersion}&distribution=${c.DISTRIBUTION_MANDREL}&architecture=${c.JDK_ARCH}&operating_system=${c.JDK_PLATFORM}&latest=per_distro`
-  const _http = new httpClient.HttpClient('http-client-tests')
+  const _http = new httpClient.HttpClient()
   const response = await _http.getJson<JdkData>(url)
   if (response.statusCode !== 200) {
     throw new Error(


### PR DESCRIPTION
- Get latest mandrel release if version not specified
- Remove user-agent from HttpClient constructor
