### PR TITLE
Upgrade node-version to v20.

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -26,10 +26,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set Node.js 16.x
+      - name: Set Node.js 20.x
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 20.x
           cache: npm
 
       - name: Install dependencies


### PR DESCRIPTION
For context: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

Ref. #78 

Upgrade the `node-version` in `.github/workflows/check-dist.yml` to v20.