### PR TITLE
Upgrade to `macos-12`.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,8 +29,8 @@ jobs:
         distribution: ['graalvm', 'graalvm-community']
         os: [
           ubuntu-latest,
-          macos-14, # macOS on Apple silicon
-          macos-12, # macOS on Intel
+          macos-latest, # macOS on Apple silicon
+          macos-12,     # macOS on Intel
           windows-latest
         ]
         components: ['']
@@ -109,7 +109,7 @@ jobs:
           - version: '22.3.1'
             java-version: '11' # for JDK 11 notification
             components: 'native-image'
-            os: macos-11
+            os: macos-12
           - version: '22.3.1'
             java-version: '17'
             components: 'native-image'


### PR DESCRIPTION
This PR ensures the test matrix for GitHub Action for GraalVM uses `macos-12` as opposed to `macos-11`, which was removed in June 2024: https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/.