### PR TITLE
Upgrade musl and follow recommendation.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        java-version: ['22', '21', '17', '20', 'dev']
+        java-version: ['23', '21', '17', '20', 'dev']
         distribution: ['graalvm', 'graalvm-community']
         os: [
           ubuntu-latest,
@@ -39,7 +39,7 @@ jobs:
           - java-version: 'latest-ea'
             distribution: 'graalvm'
             os: ubuntu-latest
-          - java-version: '23-ea'
+          - java-version: '24-ea'
             distribution: 'graalvm'
             os: ubuntu-latest
           - java-version: '21'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
         os: [
           ubuntu-latest,
           macos-latest, # macOS on Apple silicon
-          macos-12,     # macOS on Intel
+          macos-13,     # macOS on Intel
           windows-latest
         ]
         set-gds-token: [false]
@@ -119,7 +119,7 @@ jobs:
           - version: '22.3.1'
             java-version: '11' # for JDK 11 notification
             components: 'native-image'
-            os: macos-12
+            os: macos-13
           - version: '22.3.1'
             java-version: '17'
             components: 'native-image'

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -90415,7 +90415,7 @@ else {
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ERROR_HINT = exports.ERROR_REQUEST = exports.EVENT_NAME_PULL_REQUEST = exports.ENV_GITHUB_EVENT_NAME = exports.GDS_GRAALVM_PRODUCT_ID = exports.GDS_BASE = exports.MANDREL_NAMESPACE = exports.GRAALVM_RELEASES_REPO = exports.GRAALVM_PLATFORM = exports.GRAALVM_GH_USER = exports.GRAALVM_FILE_EXTENSION = exports.GRAALVM_ARCH = exports.JDK_HOME_SUFFIX = exports.JDK_PLATFORM = exports.JDK_ARCH = exports.VERSION_LATEST = exports.VERSION_DEV = exports.DISTRIBUTION_LIBERICA = exports.DISTRIBUTION_MANDREL = exports.DISTRIBUTION_GRAALVM_COMMUNITY = exports.DISTRIBUTION_GRAALVM = exports.EXECUTABLE_SUFFIX = exports.IS_WINDOWS = exports.IS_MACOS = exports.IS_LINUX = exports.INPUT_NI_MUSL = exports.INPUT_CHECK_FOR_UPDATES = exports.INPUT_CACHE = exports.INPUT_SET_JAVA_HOME = exports.INPUT_GITHUB_TOKEN = exports.INPUT_COMPONENTS = exports.INPUT_DISTRIBUTION = exports.INPUT_JAVA_PACKAGE = exports.INPUT_JAVA_VERSION = exports.INPUT_GDS_TOKEN = exports.INPUT_VERSION = exports.ACTION_VERSION = void 0;
-exports.ACTION_VERSION = '1.2.4';
+exports.ACTION_VERSION = '1.2.5';
 exports.INPUT_VERSION = 'version';
 exports.INPUT_GDS_TOKEN = 'gds-token';
 exports.INPUT_JAVA_VERSION = 'java-version';

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -90981,7 +90981,7 @@ function wrappy (fn, cb) {
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ERROR_HINT = exports.ERROR_REQUEST = exports.EVENT_NAME_PULL_REQUEST = exports.ENV_GITHUB_EVENT_NAME = exports.GDS_GRAALVM_PRODUCT_ID = exports.GDS_BASE = exports.MANDREL_NAMESPACE = exports.GRAALVM_RELEASES_REPO = exports.GRAALVM_PLATFORM = exports.GRAALVM_GH_USER = exports.GRAALVM_FILE_EXTENSION = exports.GRAALVM_ARCH = exports.JDK_HOME_SUFFIX = exports.JDK_PLATFORM = exports.JDK_ARCH = exports.VERSION_LATEST = exports.VERSION_DEV = exports.DISTRIBUTION_LIBERICA = exports.DISTRIBUTION_MANDREL = exports.DISTRIBUTION_GRAALVM_COMMUNITY = exports.DISTRIBUTION_GRAALVM = exports.EXECUTABLE_SUFFIX = exports.IS_WINDOWS = exports.IS_MACOS = exports.IS_LINUX = exports.INPUT_NI_MUSL = exports.INPUT_CHECK_FOR_UPDATES = exports.INPUT_CACHE = exports.INPUT_SET_JAVA_HOME = exports.INPUT_GITHUB_TOKEN = exports.INPUT_COMPONENTS = exports.INPUT_DISTRIBUTION = exports.INPUT_JAVA_PACKAGE = exports.INPUT_JAVA_VERSION = exports.INPUT_GDS_TOKEN = exports.INPUT_VERSION = exports.ACTION_VERSION = void 0;
-exports.ACTION_VERSION = '1.2.4';
+exports.ACTION_VERSION = '1.2.5';
 exports.INPUT_VERSION = 'version';
 exports.INPUT_GDS_TOKEN = 'gds-token';
 exports.INPUT_JAVA_VERSION = 'java-version';

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -91466,8 +91466,12 @@ const core = __importStar(__nccwpck_require__(2186));
 const tc = __importStar(__nccwpck_require__(7784));
 const utils_1 = __nccwpck_require__(1314);
 const path_1 = __nccwpck_require__(1017);
-const MUSL_NAME = 'x86_64-linux-musl-native';
-const MUSL_VERSION = '10.2.1';
+const os_1 = __nccwpck_require__(2037);
+const fs_1 = __nccwpck_require__(7147);
+const MUSL_NAME = 'musl-gcc';
+const MUSL_VERSION = '1.2.4';
+const ZLIB_VERSION = '1.2.13';
+// Build instructions: https://github.com/oracle/graal/blob/6dab549194b85252f88bda4ee825762d8b02c687/docs/reference-manual/native-image/guides/build-static-and-mostly-static-executable.md?plain=1#L38-L67
 function setUpNativeImageMusl() {
     return __awaiter(this, void 0, void 0, function* () {
         if (!c.IS_LINUX) {
@@ -91476,26 +91480,35 @@ function setUpNativeImageMusl() {
         }
         let toolPath = tc.find(MUSL_NAME, MUSL_VERSION);
         if (toolPath) {
-            core.info(`Found ${MUSL_NAME} ${MUSL_VERSION} in tool-cache @ ${toolPath}`);
+            core.info(`Found musl ${MUSL_VERSION} in tool-cache @ ${toolPath}`);
         }
         else {
-            core.startGroup(`Setting up musl for GraalVM Native Image...`);
-            const muslDownloadPath = yield tc.downloadTool(`https://github.com/graalvm/setup-graalvm/releases/download/x86_64-linux-musl-${MUSL_VERSION}/${MUSL_NAME}.tgz`);
+            core.startGroup(`Building musl with zlib for GraalVM Native Image...`);
+            // Build musl
+            const muslHome = (0, path_1.join)((0, os_1.homedir)(), 'musl-toolchain');
+            const muslDownloadPath = yield tc.downloadTool(`https://musl.libc.org/releases/musl-${MUSL_VERSION}.tar.gz`);
             const muslExtractPath = yield tc.extractTar(muslDownloadPath);
-            const muslPath = (0, path_1.join)(muslExtractPath, MUSL_NAME);
-            const zlibCommit = 'ec3df00224d4b396e2ac6586ab5d25f673caa4c2';
-            const zlibDownloadPath = yield tc.downloadTool(`https://github.com/madler/zlib/archive/${zlibCommit}.tar.gz`);
+            const muslPath = (0, path_1.join)(muslExtractPath, `musl-${MUSL_VERSION}`);
+            const muslBuildOptions = { cwd: muslPath };
+            yield (0, utils_1.exec)('./configure', [`--prefix=${muslHome}`, '--static'], muslBuildOptions);
+            yield (0, utils_1.exec)('make', [], muslBuildOptions);
+            yield (0, utils_1.exec)('make', ['install'], muslBuildOptions);
+            const muslGCC = (0, path_1.join)(muslHome, 'bin', MUSL_NAME);
+            yield fs_1.promises.symlink(muslGCC, (0, path_1.join)(muslHome, 'bin', 'x86_64-linux-musl-gcc'), 'file');
+            // Build zlib
+            const zlibDownloadPath = yield tc.downloadTool(`https://zlib.net/fossils/zlib-${ZLIB_VERSION}.tar.gz`);
             const zlibExtractPath = yield tc.extractTar(zlibDownloadPath);
-            const zlibPath = (0, path_1.join)(zlibExtractPath, `zlib-${zlibCommit}`);
+            const zlibPath = (0, path_1.join)(zlibExtractPath, `zlib-${ZLIB_VERSION}`);
             const zlibBuildOptions = {
                 cwd: zlibPath,
-                env: Object.assign(Object.assign({}, process.env), { CC: (0, path_1.join)(muslPath, 'bin', 'gcc') })
+                env: Object.assign(Object.assign({}, process.env), { CC: muslGCC })
             };
-            yield (0, utils_1.exec)('./configure', [`--prefix=${muslPath}`, '--static'], zlibBuildOptions);
+            yield (0, utils_1.exec)('./configure', [`--prefix=${muslHome}`, '--static'], zlibBuildOptions);
             yield (0, utils_1.exec)('make', [], zlibBuildOptions);
             yield (0, utils_1.exec)('make', ['install'], { cwd: zlibPath });
-            core.info(`Adding ${MUSL_NAME} ${MUSL_VERSION} to tool-cache ...`);
-            toolPath = yield tc.cacheDir(muslPath, MUSL_NAME, MUSL_VERSION);
+            // Store in cache
+            core.info(`Adding musl ${MUSL_VERSION} with zlib ${ZLIB_VERSION} to tool-cache ...`);
+            toolPath = yield tc.cacheDir(muslHome, MUSL_NAME, MUSL_VERSION);
             core.endGroup();
         }
         core.addPath((0, path_1.join)(toolPath, 'bin'));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "setup-graalvm",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "setup-graalvm",
-      "version": "1.2.4",
+      "version": "1.2.5",
       "license": "UPL",
       "dependencies": {
         "@actions/cache": "^3.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-graalvm",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "private": true,
   "description": "GitHub Action for GraalVM",
   "main": "lib/main.js",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,6 @@
 import * as otypes from '@octokit/types'
 
-export const ACTION_VERSION = '1.2.4'
+export const ACTION_VERSION = '1.2.5'
 
 export const INPUT_VERSION = 'version'
 export const INPUT_GDS_TOKEN = 'gds-token'

--- a/src/features/musl.ts
+++ b/src/features/musl.ts
@@ -3,9 +3,14 @@ import * as core from '@actions/core'
 import * as tc from '@actions/tool-cache'
 import {exec} from '../utils'
 import {join} from 'path'
+import {homedir} from 'os'
+import {promises as fs} from 'fs'
 
-const MUSL_NAME = 'x86_64-linux-musl-native'
-const MUSL_VERSION = '10.2.1'
+const MUSL_NAME = 'musl-gcc'
+const MUSL_VERSION = '1.2.4'
+const ZLIB_VERSION = '1.2.13'
+
+// Build instructions: https://github.com/oracle/graal/blob/6dab549194b85252f88bda4ee825762d8b02c687/docs/reference-manual/native-image/guides/build-static-and-mostly-static-executable.md?plain=1#L38-L67
 
 export async function setUpNativeImageMusl(): Promise<void> {
   if (!c.IS_LINUX) {
@@ -14,38 +19,55 @@ export async function setUpNativeImageMusl(): Promise<void> {
   }
   let toolPath = tc.find(MUSL_NAME, MUSL_VERSION)
   if (toolPath) {
-    core.info(`Found ${MUSL_NAME} ${MUSL_VERSION} in tool-cache @ ${toolPath}`)
+    core.info(`Found musl ${MUSL_VERSION} in tool-cache @ ${toolPath}`)
   } else {
-    core.startGroup(`Setting up musl for GraalVM Native Image...`)
+    core.startGroup(`Building musl with zlib for GraalVM Native Image...`)
+    // Build musl
+    const muslHome = join(homedir(), 'musl-toolchain')
     const muslDownloadPath = await tc.downloadTool(
-      `https://github.com/graalvm/setup-graalvm/releases/download/x86_64-linux-musl-${MUSL_VERSION}/${MUSL_NAME}.tgz`
+      `https://musl.libc.org/releases/musl-${MUSL_VERSION}.tar.gz`
     )
     const muslExtractPath = await tc.extractTar(muslDownloadPath)
-    const muslPath = join(muslExtractPath, MUSL_NAME)
-
-    const zlibCommit = 'ec3df00224d4b396e2ac6586ab5d25f673caa4c2'
+    const muslPath = join(muslExtractPath, `musl-${MUSL_VERSION}`)
+    const muslBuildOptions = {cwd: muslPath}
+    await exec(
+      './configure',
+      [`--prefix=${muslHome}`, '--static'],
+      muslBuildOptions
+    )
+    await exec('make', [], muslBuildOptions)
+    await exec('make', ['install'], muslBuildOptions)
+    const muslGCC = join(muslHome, 'bin', MUSL_NAME)
+    await fs.symlink(
+      muslGCC,
+      join(muslHome, 'bin', 'x86_64-linux-musl-gcc'),
+      'file'
+    )
+    // Build zlib
     const zlibDownloadPath = await tc.downloadTool(
-      `https://github.com/madler/zlib/archive/${zlibCommit}.tar.gz`
+      `https://zlib.net/fossils/zlib-${ZLIB_VERSION}.tar.gz`
     )
     const zlibExtractPath = await tc.extractTar(zlibDownloadPath)
-    const zlibPath = join(zlibExtractPath, `zlib-${zlibCommit}`)
+    const zlibPath = join(zlibExtractPath, `zlib-${ZLIB_VERSION}`)
     const zlibBuildOptions = {
       cwd: zlibPath,
       env: {
         ...process.env,
-        CC: join(muslPath, 'bin', 'gcc')
+        CC: muslGCC
       }
     }
     await exec(
       './configure',
-      [`--prefix=${muslPath}`, '--static'],
+      [`--prefix=${muslHome}`, '--static'],
       zlibBuildOptions
     )
     await exec('make', [], zlibBuildOptions)
     await exec('make', ['install'], {cwd: zlibPath})
-
-    core.info(`Adding ${MUSL_NAME} ${MUSL_VERSION} to tool-cache ...`)
-    toolPath = await tc.cacheDir(muslPath, MUSL_NAME, MUSL_VERSION)
+    // Store in cache
+    core.info(
+      `Adding musl ${MUSL_VERSION} with zlib ${ZLIB_VERSION} to tool-cache ...`
+    )
+    toolPath = await tc.cacheDir(muslHome, MUSL_NAME, MUSL_VERSION)
     core.endGroup()
   }
   core.addPath(join(toolPath, 'bin'))


### PR DESCRIPTION
This PR updates musl to `1.2.4` and zlib to `1.2.13` (see [the latest recommendation](https://github.com/oracle/graal/blob/6dab549194b85252f88bda4ee825762d8b02c687/docs/reference-manual/native-image/guides/build-static-and-mostly-static-executable.md?plain=1#L38-L67)). Since newer community builds of musl are no longer available on musl.cc, musl and zlib are now built from source. This takes around 30s on a free GitHub Action runner.

FYI @Friendseeker