### PR TITLE
Revert back to previous musl version.

### DIFF
--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -90415,7 +90415,7 @@ else {
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ERROR_HINT = exports.ERROR_REQUEST = exports.EVENT_NAME_PULL_REQUEST = exports.ENV_GITHUB_EVENT_NAME = exports.GDS_GRAALVM_PRODUCT_ID = exports.GDS_BASE = exports.MANDREL_NAMESPACE = exports.GRAALVM_RELEASES_REPO = exports.GRAALVM_PLATFORM = exports.GRAALVM_GH_USER = exports.GRAALVM_FILE_EXTENSION = exports.GRAALVM_ARCH = exports.JDK_HOME_SUFFIX = exports.JDK_PLATFORM = exports.JDK_ARCH = exports.VERSION_LATEST = exports.VERSION_DEV = exports.DISTRIBUTION_LIBERICA = exports.DISTRIBUTION_MANDREL = exports.DISTRIBUTION_GRAALVM_COMMUNITY = exports.DISTRIBUTION_GRAALVM = exports.EXECUTABLE_SUFFIX = exports.IS_WINDOWS = exports.IS_MACOS = exports.IS_LINUX = exports.INPUT_NI_MUSL = exports.INPUT_CHECK_FOR_UPDATES = exports.INPUT_CACHE = exports.INPUT_SET_JAVA_HOME = exports.INPUT_GITHUB_TOKEN = exports.INPUT_COMPONENTS = exports.INPUT_DISTRIBUTION = exports.INPUT_JAVA_PACKAGE = exports.INPUT_JAVA_VERSION = exports.INPUT_GDS_TOKEN = exports.INPUT_VERSION = exports.ACTION_VERSION = void 0;
-exports.ACTION_VERSION = '1.2.5';
+exports.ACTION_VERSION = '1.2.6';
 exports.INPUT_VERSION = 'version';
 exports.INPUT_GDS_TOKEN = 'gds-token';
 exports.INPUT_JAVA_VERSION = 'java-version';

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -90981,7 +90981,7 @@ function wrappy (fn, cb) {
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.ERROR_HINT = exports.ERROR_REQUEST = exports.EVENT_NAME_PULL_REQUEST = exports.ENV_GITHUB_EVENT_NAME = exports.GDS_GRAALVM_PRODUCT_ID = exports.GDS_BASE = exports.MANDREL_NAMESPACE = exports.GRAALVM_RELEASES_REPO = exports.GRAALVM_PLATFORM = exports.GRAALVM_GH_USER = exports.GRAALVM_FILE_EXTENSION = exports.GRAALVM_ARCH = exports.JDK_HOME_SUFFIX = exports.JDK_PLATFORM = exports.JDK_ARCH = exports.VERSION_LATEST = exports.VERSION_DEV = exports.DISTRIBUTION_LIBERICA = exports.DISTRIBUTION_MANDREL = exports.DISTRIBUTION_GRAALVM_COMMUNITY = exports.DISTRIBUTION_GRAALVM = exports.EXECUTABLE_SUFFIX = exports.IS_WINDOWS = exports.IS_MACOS = exports.IS_LINUX = exports.INPUT_NI_MUSL = exports.INPUT_CHECK_FOR_UPDATES = exports.INPUT_CACHE = exports.INPUT_SET_JAVA_HOME = exports.INPUT_GITHUB_TOKEN = exports.INPUT_COMPONENTS = exports.INPUT_DISTRIBUTION = exports.INPUT_JAVA_PACKAGE = exports.INPUT_JAVA_VERSION = exports.INPUT_GDS_TOKEN = exports.INPUT_VERSION = exports.ACTION_VERSION = void 0;
-exports.ACTION_VERSION = '1.2.5';
+exports.ACTION_VERSION = '1.2.6';
 exports.INPUT_VERSION = 'version';
 exports.INPUT_GDS_TOKEN = 'gds-token';
 exports.INPUT_JAVA_VERSION = 'java-version';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "setup-graalvm",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "setup-graalvm",
-      "version": "1.2.5",
+      "version": "1.2.6",
       "license": "UPL",
       "dependencies": {
         "@actions/cache": "^3.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-graalvm",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "private": true,
   "description": "GitHub Action for GraalVM",
   "main": "lib/main.js",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,6 @@
 import * as otypes from '@octokit/types'
 
-export const ACTION_VERSION = '1.2.5'
+export const ACTION_VERSION = '1.2.6'
 
 export const INPUT_VERSION = 'version'
 export const INPUT_GDS_TOKEN = 'gds-token'

--- a/src/features/musl.ts
+++ b/src/features/musl.ts
@@ -3,14 +3,9 @@ import * as core from '@actions/core'
 import * as tc from '@actions/tool-cache'
 import {exec} from '../utils'
 import {join} from 'path'
-import {homedir} from 'os'
-import {promises as fs} from 'fs'
 
-const MUSL_NAME = 'musl-gcc'
-const MUSL_VERSION = '1.2.4'
-const ZLIB_VERSION = '1.2.13'
-
-// Build instructions: https://github.com/oracle/graal/blob/6dab549194b85252f88bda4ee825762d8b02c687/docs/reference-manual/native-image/guides/build-static-and-mostly-static-executable.md?plain=1#L38-L67
+const MUSL_NAME = 'x86_64-linux-musl-native'
+const MUSL_VERSION = '10.2.1'
 
 export async function setUpNativeImageMusl(): Promise<void> {
   if (!c.IS_LINUX) {
@@ -19,55 +14,38 @@ export async function setUpNativeImageMusl(): Promise<void> {
   }
   let toolPath = tc.find(MUSL_NAME, MUSL_VERSION)
   if (toolPath) {
-    core.info(`Found musl ${MUSL_VERSION} in tool-cache @ ${toolPath}`)
+    core.info(`Found ${MUSL_NAME} ${MUSL_VERSION} in tool-cache @ ${toolPath}`)
   } else {
-    core.startGroup(`Building musl with zlib for GraalVM Native Image...`)
-    // Build musl
-    const muslHome = join(homedir(), 'musl-toolchain')
+    core.startGroup(`Setting up musl for GraalVM Native Image...`)
     const muslDownloadPath = await tc.downloadTool(
-      `https://musl.libc.org/releases/musl-${MUSL_VERSION}.tar.gz`
+      `https://github.com/graalvm/setup-graalvm/releases/download/x86_64-linux-musl-${MUSL_VERSION}/${MUSL_NAME}.tgz`
     )
     const muslExtractPath = await tc.extractTar(muslDownloadPath)
-    const muslPath = join(muslExtractPath, `musl-${MUSL_VERSION}`)
-    const muslBuildOptions = {cwd: muslPath}
-    await exec(
-      './configure',
-      [`--prefix=${muslHome}`, '--static'],
-      muslBuildOptions
-    )
-    await exec('make', [], muslBuildOptions)
-    await exec('make', ['install'], muslBuildOptions)
-    const muslGCC = join(muslHome, 'bin', MUSL_NAME)
-    await fs.symlink(
-      muslGCC,
-      join(muslHome, 'bin', 'x86_64-linux-musl-gcc'),
-      'file'
-    )
-    // Build zlib
+    const muslPath = join(muslExtractPath, MUSL_NAME)
+
+    const zlibCommit = 'ec3df00224d4b396e2ac6586ab5d25f673caa4c2'
     const zlibDownloadPath = await tc.downloadTool(
-      `https://zlib.net/fossils/zlib-${ZLIB_VERSION}.tar.gz`
+      `https://github.com/madler/zlib/archive/${zlibCommit}.tar.gz`
     )
     const zlibExtractPath = await tc.extractTar(zlibDownloadPath)
-    const zlibPath = join(zlibExtractPath, `zlib-${ZLIB_VERSION}`)
+    const zlibPath = join(zlibExtractPath, `zlib-${zlibCommit}`)
     const zlibBuildOptions = {
       cwd: zlibPath,
       env: {
         ...process.env,
-        CC: muslGCC
+        CC: join(muslPath, 'bin', 'gcc')
       }
     }
     await exec(
       './configure',
-      [`--prefix=${muslHome}`, '--static'],
+      [`--prefix=${muslPath}`, '--static'],
       zlibBuildOptions
     )
     await exec('make', [], zlibBuildOptions)
     await exec('make', ['install'], {cwd: zlibPath})
-    // Store in cache
-    core.info(
-      `Adding musl ${MUSL_VERSION} with zlib ${ZLIB_VERSION} to tool-cache ...`
-    )
-    toolPath = await tc.cacheDir(muslHome, MUSL_NAME, MUSL_VERSION)
+
+    core.info(`Adding ${MUSL_NAME} ${MUSL_VERSION} to tool-cache ...`)
+    toolPath = await tc.cacheDir(muslPath, MUSL_NAME, MUSL_VERSION)
     core.endGroup()
   }
   core.addPath(join(toolPath, 'bin'))


### PR DESCRIPTION
This PR reverts https://github.com/graalvm/setup-graalvm/pull/114/commits/21d4e64280cabb960802bb0d8f0971f25e72641e. Unfortunately, the [musl-gcc wrapper does not support C++](https://wiki.musl-libc.org/getting-started.html) which is needed to build static images with G1 GC and others. While we are working on a better solution, we are reverting back to the previous musl integration.