### PR TITLE
Start testing on `ubuntu-22.04-arm`.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,8 @@ jobs:
         java-version: ['23', '21', '17', '20', 'dev']
         distribution: ['graalvm', 'graalvm-community']
         os: [
-            ubuntu-latest,
+            ubuntu-latest, # Linux on Intel
+            ubuntu-22.04-arm, # Linux on arm64
             macos-latest, # macOS on Apple silicon
             macos-13, # macOS on Intel
             windows-latest


### PR DESCRIPTION
Context: [Linux arm64 hosted runners now available for free in public repositories (Public Preview)](https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/)