### PR TITLE
SBOM: Ensure 'java-version' is persisted to post-run phase

### DIFF
--- a/__tests__/sbom.test.ts
+++ b/__tests__/sbom.test.ts
@@ -145,6 +145,7 @@ describe('sbom feature', () => {
       writeFileSync(sbomPath, JSON.stringify(sbom, null, 2))
 
       mockFindSBOM([sbomPath])
+      jest.spyOn(core, 'getState').mockReturnValue(javaVersion)
 
       await processSBOM()
     }
@@ -189,6 +190,10 @@ describe('sbom feature', () => {
         }
       ]
     }
+
+    it('should throw an error if setUpSBOMSupport was not called before processSBOM', async () => {
+      await expect(processSBOM()).rejects.toThrow('setUpSBOMSupport must be called before processSBOM')
+    })
 
     it('should process SBOM and display components', async () => {
       await setUpAndProcessSBOM(sampleSBOM)

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -78738,36 +78738,37 @@ const utils_1 = __nccwpck_require__(1798);
 const INPUT_NI_SBOM = 'native-image-enable-sbom';
 const SBOM_FILE_SUFFIX = '.sbom.json';
 const MIN_JAVA_VERSION = '24.0.0';
-let javaVersionOrLatestEA = null;
-function setUpSBOMSupport(javaVersionOrDev, distribution) {
+const javaVersionKey = 'javaVersionKey';
+function setUpSBOMSupport(javaVersion, distribution) {
     if (!isFeatureEnabled()) {
         return;
     }
-    validateJavaVersionAndDistribution(javaVersionOrDev, distribution);
-    javaVersionOrLatestEA = javaVersionOrDev;
-    (0, utils_1.setNativeImageOption)(javaVersionOrLatestEA, '--enable-sbom=export');
+    validateJavaVersionAndDistribution(javaVersion, distribution);
+    core.saveState(javaVersionKey, javaVersion);
+    (0, utils_1.setNativeImageOption)(javaVersion, '--enable-sbom=export');
     core.info('Enabled SBOM generation for Native Image build');
 }
-function validateJavaVersionAndDistribution(javaVersionOrDev, distribution) {
+function validateJavaVersionAndDistribution(javaVersion, distribution) {
     if (distribution !== c.DISTRIBUTION_GRAALVM) {
         throw new Error(`The '${INPUT_NI_SBOM}' option is only supported for Oracle GraalVM (distribution '${c.DISTRIBUTION_GRAALVM}'), but found distribution '${distribution}'.`);
     }
-    if (javaVersionOrDev === 'dev') {
+    if (javaVersion === 'dev') {
         throw new Error(`The '${INPUT_NI_SBOM}' option is not supported for java-version 'dev'.`);
     }
-    if (javaVersionOrDev === 'latest-ea') {
+    if (javaVersion === 'latest-ea') {
         return;
     }
-    const coercedJavaVersion = semver.coerce(javaVersionOrDev);
+    const coercedJavaVersion = semver.coerce(javaVersion);
     if (!coercedJavaVersion || semver.gt(MIN_JAVA_VERSION, coercedJavaVersion)) {
-        throw new Error(`The '${INPUT_NI_SBOM}' option is only supported for GraalVM for JDK ${MIN_JAVA_VERSION} or later, but found java-version '${javaVersionOrDev}'.`);
+        throw new Error(`The '${INPUT_NI_SBOM}' option is only supported for GraalVM for JDK ${MIN_JAVA_VERSION} or later, but found java-version '${javaVersion}'.`);
     }
 }
 async function processSBOM() {
     if (!isFeatureEnabled()) {
         return;
     }
-    if (javaVersionOrLatestEA === null) {
+    const javaVersion = core.getState(javaVersionKey);
+    if (!javaVersion) {
         throw new Error('setUpSBOMSupport must be called before processSBOM');
     }
     const sbomPath = await findSBOMFilePath();
@@ -78776,7 +78777,7 @@ async function processSBOM() {
         const sbomData = parseSBOM(sbomContent);
         const components = mapToComponentsWithDependencies(sbomData);
         printSBOMContent(components);
-        const snapshot = convertSBOMToSnapshot(sbomPath, components);
+        const snapshot = convertSBOMToSnapshot(javaVersion, sbomPath, components);
         await submitDependencySnapshot(snapshot);
     }
     catch (error) {
@@ -78833,7 +78834,7 @@ function printSBOMContent(components) {
     }
     core.info('==================');
 }
-function convertSBOMToSnapshot(sbomPath, components) {
+function convertSBOMToSnapshot(javaVersion, sbomPath, components) {
     const context = github.context;
     const sbomFileName = (0, path_1.basename)(sbomPath);
     if (!sbomFileName.endsWith(SBOM_FILE_SUFFIX)) {
@@ -78850,7 +78851,7 @@ function convertSBOMToSnapshot(sbomPath, components) {
         },
         detector: {
             name: 'Oracle GraalVM',
-            version: javaVersionOrLatestEA ?? '',
+            version: javaVersion,
             url: 'https://www.graalvm.org/'
         },
         scanned: new Date().toISOString(),

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -78852,36 +78852,37 @@ const utils_1 = __nccwpck_require__(1798);
 const INPUT_NI_SBOM = 'native-image-enable-sbom';
 const SBOM_FILE_SUFFIX = '.sbom.json';
 const MIN_JAVA_VERSION = '24.0.0';
-let javaVersionOrLatestEA = null;
-function setUpSBOMSupport(javaVersionOrDev, distribution) {
+const javaVersionKey = 'javaVersionKey';
+function setUpSBOMSupport(javaVersion, distribution) {
     if (!isFeatureEnabled()) {
         return;
     }
-    validateJavaVersionAndDistribution(javaVersionOrDev, distribution);
-    javaVersionOrLatestEA = javaVersionOrDev;
-    (0, utils_1.setNativeImageOption)(javaVersionOrLatestEA, '--enable-sbom=export');
+    validateJavaVersionAndDistribution(javaVersion, distribution);
+    core.saveState(javaVersionKey, javaVersion);
+    (0, utils_1.setNativeImageOption)(javaVersion, '--enable-sbom=export');
     core.info('Enabled SBOM generation for Native Image build');
 }
-function validateJavaVersionAndDistribution(javaVersionOrDev, distribution) {
+function validateJavaVersionAndDistribution(javaVersion, distribution) {
     if (distribution !== c.DISTRIBUTION_GRAALVM) {
         throw new Error(`The '${INPUT_NI_SBOM}' option is only supported for Oracle GraalVM (distribution '${c.DISTRIBUTION_GRAALVM}'), but found distribution '${distribution}'.`);
     }
-    if (javaVersionOrDev === 'dev') {
+    if (javaVersion === 'dev') {
         throw new Error(`The '${INPUT_NI_SBOM}' option is not supported for java-version 'dev'.`);
     }
-    if (javaVersionOrDev === 'latest-ea') {
+    if (javaVersion === 'latest-ea') {
         return;
     }
-    const coercedJavaVersion = semver.coerce(javaVersionOrDev);
+    const coercedJavaVersion = semver.coerce(javaVersion);
     if (!coercedJavaVersion || semver.gt(MIN_JAVA_VERSION, coercedJavaVersion)) {
-        throw new Error(`The '${INPUT_NI_SBOM}' option is only supported for GraalVM for JDK ${MIN_JAVA_VERSION} or later, but found java-version '${javaVersionOrDev}'.`);
+        throw new Error(`The '${INPUT_NI_SBOM}' option is only supported for GraalVM for JDK ${MIN_JAVA_VERSION} or later, but found java-version '${javaVersion}'.`);
     }
 }
 async function processSBOM() {
     if (!isFeatureEnabled()) {
         return;
     }
-    if (javaVersionOrLatestEA === null) {
+    const javaVersion = core.getState(javaVersionKey);
+    if (!javaVersion) {
         throw new Error('setUpSBOMSupport must be called before processSBOM');
     }
     const sbomPath = await findSBOMFilePath();
@@ -78890,7 +78891,7 @@ async function processSBOM() {
         const sbomData = parseSBOM(sbomContent);
         const components = mapToComponentsWithDependencies(sbomData);
         printSBOMContent(components);
-        const snapshot = convertSBOMToSnapshot(sbomPath, components);
+        const snapshot = convertSBOMToSnapshot(javaVersion, sbomPath, components);
         await submitDependencySnapshot(snapshot);
     }
     catch (error) {
@@ -78947,7 +78948,7 @@ function printSBOMContent(components) {
     }
     core.info('==================');
 }
-function convertSBOMToSnapshot(sbomPath, components) {
+function convertSBOMToSnapshot(javaVersion, sbomPath, components) {
     const context = github.context;
     const sbomFileName = (0, path_1.basename)(sbomPath);
     if (!sbomFileName.endsWith(SBOM_FILE_SUFFIX)) {
@@ -78964,7 +78965,7 @@ function convertSBOMToSnapshot(sbomPath, components) {
         },
         detector: {
             name: 'Oracle GraalVM',
-            version: javaVersionOrLatestEA ?? '',
+            version: javaVersion,
             url: 'https://www.graalvm.org/'
         },
         scanned: new Date().toISOString(),


### PR DESCRIPTION
The SBOM integration tests emitted this warning in the post-run phase
```
Warning: Error: setUpSBOMSupport must be called before processSBOM
```
Example [here](https://github.com/graalvm/setup-graalvm/actions/runs/13625927646/job/38083085510#step:9:2).

This PR resolves this issue. The problem was that the post-run phase of the SBOM feature read a variable that was not persisted from the main phase. The solution is to use the `core.saveState` and `core.getState` API. 