### PR TITLE
Add Visual Studio 2026 to known installations

### DIFF
--- a/dist/cleanup.js
+++ b/dist/cleanup.js
@@ -29939,7 +29939,7 @@ function getState(name) {
     return process.env[`STATE_${name}`] || '';
 }
 
-const ACTION_VERSION = '1.5.4';
+const ACTION_VERSION = '1.5.5';
 const INPUT_GITHUB_TOKEN = 'github-token';
 const INPUT_CACHE = 'cache';
 process.platform === 'linux';

--- a/dist/main.js
+++ b/dist/main.js
@@ -83322,7 +83322,8 @@ async function setUpNativeImageMusl() {
 
 // Keep in sync with https://github.com/actions/virtual-environments
 const KNOWN_VISUAL_STUDIO_INSTALLATIONS = [
-    'C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise', // 'windows-2022' and 'windows-latest'
+    'C:\\Program Files\\Microsoft Visual Studio\\2026\\Enterprise', // 'windows-2025' and 'windows-latest'
+    'C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise', // 'windows-2022'
     'C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise', // 'windows-2019'
     'C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Enterprise' // 'windows-2016' (deprecated and removed)
 ];

--- a/dist/main.js
+++ b/dist/main.js
@@ -51,7 +51,7 @@ import require$$1$5 from 'tty';
 import { createHmac } from 'node:crypto';
 import fs$1 from 'node:fs';
 
-const ACTION_VERSION = '1.5.4';
+const ACTION_VERSION = '1.5.5';
 const INPUT_VERSION = 'version';
 const INPUT_GDS_TOKEN = 'gds-token';
 const INPUT_JAVA_VERSION = 'java-version';

--- a/dist/main.js
+++ b/dist/main.js
@@ -83322,7 +83322,7 @@ async function setUpNativeImageMusl() {
 
 // Keep in sync with https://github.com/actions/virtual-environments
 const KNOWN_VISUAL_STUDIO_INSTALLATIONS = [
-    'C:\\Program Files\\Microsoft Visual Studio\\2026\\Enterprise', // 'windows-2025' and 'windows-latest'
+    'C:\\Program Files\\Microsoft Visual Studio\\18\\Enterprise', // 'windows-2025' and 'windows-latest'
     'C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise', // 'windows-2022'
     'C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise', // 'windows-2019'
     'C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Enterprise' // 'windows-2016' (deprecated and removed)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "setup-graalvm",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "setup-graalvm",
-      "version": "1.5.4",
+      "version": "1.5.5",
       "license": "UPL",
       "dependencies": {
         "@actions/cache": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "setup-graalvm",
   "author": "GraalVM Community",
   "description": "GitHub Action for GraalVM",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "type": "module",
   "private": true,
   "repository": {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,6 @@
 import * as otypes from '@octokit/types'
 
-export const ACTION_VERSION = '1.5.4'
+export const ACTION_VERSION = '1.5.5'
 
 export const INPUT_VERSION = 'version'
 export const INPUT_GDS_TOKEN = 'gds-token'

--- a/src/msvc.ts
+++ b/src/msvc.ts
@@ -5,7 +5,8 @@ import { VERSION_DEV } from './constants.js'
 
 // Keep in sync with https://github.com/actions/virtual-environments
 const KNOWN_VISUAL_STUDIO_INSTALLATIONS = [
-  'C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise', // 'windows-2022' and 'windows-latest'
+  'C:\\Program Files\\Microsoft Visual Studio\\2026\\Enterprise', // 'windows-2025' and 'windows-latest'
+  'C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise', // 'windows-2022'
   'C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise', // 'windows-2019'
   'C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Enterprise' // 'windows-2016' (deprecated and removed)
 ]

--- a/src/msvc.ts
+++ b/src/msvc.ts
@@ -5,7 +5,7 @@ import { VERSION_DEV } from './constants.js'
 
 // Keep in sync with https://github.com/actions/virtual-environments
 const KNOWN_VISUAL_STUDIO_INSTALLATIONS = [
-  'C:\\Program Files\\Microsoft Visual Studio\\2026\\Enterprise', // 'windows-2025' and 'windows-latest'
+  'C:\\Program Files\\Microsoft Visual Studio\\18\\Enterprise', // 'windows-2025' and 'windows-latest'
   'C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise', // 'windows-2022'
   'C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise', // 'windows-2019'
   'C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Enterprise' // 'windows-2016' (deprecated and removed)


### PR DESCRIPTION
## Summary

Add the Visual Studio 2026 Enterprise installation path to `KNOWN_VISUAL_STUDIO_INSTALLATIONS` in `src/msvc.ts`.

## Why

The `windows-latest` GitHub Actions runner [now resolves to `windows-2025-vs2026`](https://github.com/actions/runner-images/issues/14017) (rolled out June 8–15, 2026), which ships with Visual Studio 2026. Since the VS2026 path was not listed, `findVcvarsallPath()` fails with:

```
##[error]Failed to find vcvarsall.bat
```

Example failing run: https://github.com/quarkus-qe/quarkus-test-suite/actions/runs/27516266920/job/81327476930

Fixes #218