### PR TITLE
Add support for GraalVM innovation releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         env:
           INPUT_GITHUB_TOKEN: ${{ github.token }} # for core.getInput()
 
-  test-action:
+  test-action-graalvm-version:
     name: GraalVM
     runs-on: ${{ matrix.os }}
     env:
@@ -43,7 +43,79 @@ jobs:
       PASSES_GDS_TOKEN_CHECK: ${{ !matrix.set-gds-token || secrets.GDS_TOKEN != '' }}
     strategy:
       matrix:
-        java-version: ['25', '21', '17', 'dev']
+        version: [
+            '25.1',
+            '25i1', # innovation release
+            '25.1.3', # full version
+            '25.0' # LTS release
+          ]
+        distribution: ['graalvm', 'graalvm-community']
+        os: [
+            ubuntu-latest, # Linux on Intel
+            ubuntu-22.04-arm, # Linux on arm64
+            macos-latest, # macOS on Apple silicon
+            windows-latest
+          ]
+        set-gds-token: [false]
+        include:
+          # Latest EA build
+          - version: 'latest-ea'
+            distribution: 'graalvm'
+            os: ubuntu-latest
+          # Latest dev build
+          - version: 'dev'
+            distribution: 'graalvm-community'
+            os: ubuntu-latest
+          # with GDS token
+          - version: '25.0'
+            distribution: 'graalvm'
+            os: ubuntu-latest
+            set-gds-token: true
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Run setup-graalvm action
+        uses: ./
+        with:
+          version: ${{ matrix.version }}
+          distribution: ${{ matrix.distribution }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          gds-token: ${{ matrix.set-gds-token && secrets.GDS_TOKEN || '' }}
+        if: ${{ env.PASSES_GDS_TOKEN_CHECK == 'true' }}
+      - name: Check environment
+        run: |
+          echo "GRAALVM_HOME: $GRAALVM_HOME"
+          if [[ "${{ matrix.version }}" == "dev" ]]; then
+            [[ "$GRAALVM_HOME" == *"$RUNNER_TEMP"* ]] || exit 12
+          else
+            [[ "$GRAALVM_HOME" == *"$RUNNER_TOOL_CACHE"* ]] || exit 23
+          fi
+          echo "JAVA_HOME: $JAVA_HOME"
+          java --version
+          java --version | grep "GraalVM" || exit 34
+          native-image --version
+        if: ${{ env.PASSES_GDS_TOKEN_CHECK == 'true' && runner.os != 'Windows' }}
+      - name: Check Windows environment
+        run: |
+          echo "GRAALVM_HOME: $env:GRAALVM_HOME"
+          echo "JAVA_HOME: $env:JAVA_HOME"
+          java --version
+          native-image --version
+        if: ${{ env.PASSES_GDS_TOKEN_CHECK == 'true' && runner.os == 'Windows' }}
+
+  test-action-java-version:
+    name: GraalVM
+    runs-on: ${{ matrix.os }}
+    env:
+      # Skip builds that require a GDS token but have no access to one (e.g., secrets are unavailable in PR runs)
+      PASSES_GDS_TOKEN_CHECK: ${{ !matrix.set-gds-token || secrets.GDS_TOKEN != '' }}
+    strategy:
+      matrix:
+        java-version: [
+            '25',
+            '21',
+            '17', # LTS
+            'dev' # dev build
+          ]
         distribution: ['graalvm', 'graalvm-community']
         os: [
             ubuntu-latest, # Linux on Intel
@@ -99,6 +171,7 @@ jobs:
           components: ${{ matrix.components }}
           gds-token: ${{ matrix.set-gds-token && secrets.GDS_TOKEN || '' }}
         if: ${{ env.PASSES_GDS_TOKEN_CHECK == 'true' }}
+
       - name: Check environment
         run: |
           echo "GRAALVM_HOME: $GRAALVM_HOME"
@@ -121,7 +194,7 @@ jobs:
         if: ${{ env.PASSES_GDS_TOKEN_CHECK == 'true' && runner.os == 'Windows' }}
 
   test-action-ce: # make sure the action works on a clean machine without building
-    needs: test-action
+    needs: [test-action-graalvm-version, test-action-java-version]
     name: CE ${{ matrix.version }} + JDK${{ matrix.java-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -189,7 +262,7 @@ jobs:
         if: ${{ runner.os == 'Windows' }}
 
   test-action-ee:
-    needs: test-action
+    needs: [test-action-graalvm-version, test-action-java-version]
     name: EE ${{ matrix.version }} + JDK${{ matrix.java-version }} on ${{ matrix.os }}
     if: github.event_name != 'pull_request'
     runs-on: ${{ matrix.os }}
@@ -242,7 +315,7 @@ jobs:
         if: ${{ env.PASSES_GDS_TOKEN_CHECK == 'true' && runner.os == 'Windows' }}
 
   test-action-mandrel:
-    needs: test-action
+    needs: [test-action-graalvm-version, test-action-java-version]
     name: ${{ matrix.version }} + JDK${{ matrix.java-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -299,7 +372,7 @@ jobs:
         if: ${{ runner.os == 'Windows' }}
 
   test-action-liberica:
-    needs: test-action
+    needs: [test-action-graalvm-version, test-action-java-version]
     name: Liberica (${{ matrix.java-version }}, '${{ matrix.java-package }}', ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:

--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: graalvm/setup-graalvm@v1
         with:
-          java-version: '25'      # See 'Options' for more details
+          version: '25.1'         # See 'Options' for more details
           distribution: 'graalvm' # See 'Supported distributions' for available options
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Example step
@@ -57,7 +57,7 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: graalvm/setup-graalvm@v1
         with:
@@ -80,6 +80,23 @@ jobs:
           path: helloworld*
 ```
 
+### Template for GraalVM innovation releases
+
+```yml
+name: Oracle GraalVM Innovation Release build
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: graalvm/setup-graalvm@v1
+        with:
+          version: '25.1'
+          distribution: 'graalvm'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
 ### Template for Oracle GraalVM Early Access (EA) builds
 
 ```yml
@@ -89,7 +106,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: graalvm/setup-graalvm@v1
         with:
           java-version: '25e1-ea' # or 'latest-ea' for the latest Java version available
@@ -127,7 +144,7 @@ jobs:
       build:
         runs-on: ubuntu-latest
         steps:
-          - uses: actions/checkout@v4
+          - uses: actions/checkout@v6
           - uses: graalvm/setup-graalvm@v1
             with:
               distribution: 'graalvm'
@@ -159,7 +176,7 @@ jobs:
       build:
         runs-on: ubuntu-latest
         steps:
-          - uses: actions/checkout@v4
+          - uses: actions/checkout@v6
           - uses: graalvm/setup-graalvm@v1
             with:
               version: '22.3.0'
@@ -194,7 +211,8 @@ This actions can be configured with the following options:
 
 | Name            | Default  | Description |
 |-----------------|:--------:|-------------|
-| `java-version`<br>*(required)* | n/a | Java version <ul><li>major versions: `'25'`, `'21'`, `'17'`, `'11'`, `'8'`</li><li>specific versions: `'21.0.3'`, `'17.0.11'`</li><li>early access (EA) builds: `'25e1-ea'` *(requires `distribution: 'graalvm'`)*</li><li>latest EA build: `'latest-ea'` *(requires `distribution: 'graalvm'`)*</li><li>dev builds: `'dev'` *(requires `distribution: 'graalvm-community'`)*</li></ul> |
+| `java-version`  | `''`     | Java version <ul><li>major versions: `'25'`, `'21'`, `'17'`, `'11'`, `'8'`</li><li>innovation releases: `'25i1'`</li><li>specific versions: `'25.0.3'`, `'21.0.3'`</li><li>early access (EA) builds: `'25e1-ea'` *(requires `distribution: 'graalvm'`)*</li><li>latest EA build: `'latest-ea'` *(requires `distribution: 'graalvm'`)*</li><li>dev builds: `'dev'` *(requires `distribution: 'graalvm-community'`)*</li></ul> |
+| `version`       | `''`     | `X.Y` (e.g., `25.1`) for GraalVM innovation releases starting 25.1<br>`X.Y.Z` (e.g., `22.3.0`) for a specific [GraalVM release][releases] up to `22.3.2`<br>`mandrel-X.Y.Z.W` or `X.Y.Z.W-Final` (e.g., `mandrel-21.3.0.0-Final` or `21.3.0.0-Final`) for a specific [Mandrel release][mandrel-releases],<br>`mandrel-latest` or `latest` for the latest Mandrel stable release. |
 | `distribution`  | `'graalvm'` | GraalVM distribution (see [supported distributions](#supported-distributions)) |
 | `java-package`  | `'jdk'` | The package type (`'jdk'` or `'jdk+fx'`). Currently applies to Liberica only. |
 | `github-token`  | `'${{ github.token }}'` | Token for communication with the GitHub API. Please set this to `${{ secrets.GITHUB_TOKEN }}` (see [templates](#templates)) to allow the action to authenticate with the GitHub API, which helps reduce rate-limiting issues. |
@@ -207,7 +225,6 @@ This actions can be configured with the following options:
 | `native-image-pr-reports-update-existing` *) | `'false'` | Instead of posting another comment, update an existing PR comment with the latest Native Image build report. Requires `native-image-pr-reports` to be `true`. |
 | `native-image-enable-sbom` | `'false'` | If set to `'true'`, generate a minimal SBOM based on the Native Image static analysis and submit it to GitHub's dependency submission API. This enables the [dependency graph feature](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-the-dependency-graph) for dependency tracking and vulnerability analysis. Requires `write` permissions for the [`contents` scope][gha-permissions] and the dependency graph to be actived (on by default for public repositories - see [how to activate](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/configuring-the-dependency-graph#enabling-and-disabling-the-dependency-graph-for-a-private-repository)). Only available in Oracle GraalVM for JDK 24 or later. |
 | `components`    | `''`     | Comma-separated list of GraalVM components (e.g., `native-image` or `ruby,nodejs`) that will be installed by the [GraalVM Updater][gu]. |
-| `version` | `''` | `X.Y.Z` (e.g., `22.3.0`) for a specific [GraalVM release][releases] up to `22.3.2`<br>`mandrel-X.Y.Z.W` or `X.Y.Z.W-Final` (e.g., `mandrel-21.3.0.0-Final` or `21.3.0.0-Final`) for a specific [Mandrel release][mandrel-releases],<br>`mandrel-latest` or `latest` for the latest Mandrel stable release. |
 | `gds-token`     | `''`     Download token for the GraalVM Download Service. If a non-empty token is provided, the action will set up Oracle GraalVM (see [Oracle GraalVM via GDS template](#template-for-oracle-graalvm-via-graalvm-download-service)) or GraalVM Enterprise Edition (see [GraalVM EE template](#template-for-graalvm-enterprise-edition)) via GDS. |
 
 **) Make sure that Native Image is used only once per build job. Otherwise, the report is only generated for the last Native Image build.*

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: graalvm/setup-graalvm@v1
         with:
-          version: '25.1'         # See 'Options' for more details
+          version: '25.1'         # or '25.0' for LTS; See 'Options' for more details
           distribution: 'graalvm' # See 'Supported distributions' for available options
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Example step
@@ -61,7 +61,7 @@ jobs:
 
       - uses: graalvm/setup-graalvm@v1
         with:
-          java-version: '25'
+          version: '25.0'
           distribution: 'graalvm'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           native-image-job-reports: 'true'
@@ -211,8 +211,8 @@ This actions can be configured with the following options:
 
 | Name            | Default  | Description |
 |-----------------|:--------:|-------------|
-| `java-version`  | `''`     | Java version <ul><li>major versions: `'25'`, `'21'`, `'17'`, `'11'`, `'8'`</li><li>innovation releases: `'25i1'`</li><li>specific versions: `'25.0.3'`, `'21.0.3'`</li><li>early access (EA) builds: `'25e1-ea'` *(requires `distribution: 'graalvm'`)*</li><li>latest EA build: `'latest-ea'` *(requires `distribution: 'graalvm'`)*</li><li>dev builds: `'dev'` *(requires `distribution: 'graalvm-community'`)*</li></ul> |
-| `version`       | `''`     | `X.Y` (e.g., `25.1`) for GraalVM innovation releases starting 25.1<br>`X.Y.Z` (e.g., `22.3.0`) for a specific [GraalVM release][releases] up to `22.3.2`<br>`mandrel-X.Y.Z.W` or `X.Y.Z.W-Final` (e.g., `mandrel-21.3.0.0-Final` or `21.3.0.0-Final`) for a specific [Mandrel release][mandrel-releases],<br>`mandrel-latest` or `latest` for the latest Mandrel stable release. |
+| `version`       | `''`     | `X.Y` (e.g., `25.0`) for GraalVM releases starting 25.0<br>`X.Y.Z` (e.g., `22.3.0`) for a specific [GraalVM release][releases] up to `22.3.2`<br>`mandrel-X.Y.Z.W` or `X.Y.Z.W-Final` (e.g., `mandrel-21.3.0.0-Final` or `21.3.0.0-Final`) for a specific [Mandrel release][mandrel-releases],<br>`mandrel-latest` or `latest` for the latest Mandrel stable release. |
+| `java-version`  | `''`     | Java version <ul><li>major versions: `'25'`, `'21'`, `'17'`, `'11'`, `'8'`</li><li>specific versions: `'25.0.3'`, `'21.0.3'`</li><li>early access (EA) builds: `'25e1-ea'` *(requires `distribution: 'graalvm'`)*</li><li>latest EA build: `'latest-ea'` *(requires `distribution: 'graalvm'`)*</li><li>dev builds: `'dev'` *(requires `distribution: 'graalvm-community'`)*</li></ul> |
 | `distribution`  | `'graalvm'` | GraalVM distribution (see [supported distributions](#supported-distributions)) |
 | `java-package`  | `'jdk'` | The package type (`'jdk'` or `'jdk+fx'`). Currently applies to Liberica only. |
 | `github-token`  | `'${{ github.token }}'` | Token for communication with the GitHub API. Please set this to `${{ secrets.GITHUB_TOKEN }}` (see [templates](#templates)) to allow the action to authenticate with the GitHub API, which helps reduce rate-limiting issues. |

--- a/__tests__/gds.test.ts
+++ b/__tests__/gds.test.ts
@@ -1,5 +1,11 @@
 import * as path from 'path'
-import { downloadGraalVM, downloadGraalVMEELegacy, fetchArtifact, fetchArtifactEE } from '../src/gds'
+import {
+  downloadGraalVMViaGDSByJavaVersion,
+  downloadGraalVMViaGDSByJavaVersionEELegacy,
+  fetchArtifact,
+  fetchArtifactByJavaVersion,
+  fetchArtifactEE
+} from '../src/gds'
 import { expect, test } from '@jest/globals'
 import { fileURLToPath } from 'url'
 
@@ -9,18 +15,31 @@ const dirname = path.dirname(fileURLToPath(import.meta.url))
 process.env['RUNNER_TEMP'] = path.join(dirname, 'TEMP')
 
 test('fetch artifacts', async () => {
-  let artifact = await fetchArtifact(TEST_USER_AGENT, 'isBase:True', '17.0.12')
+  let artifact
+  // Test innovation releases
+  for (const version of ['25.1', '25.1.3']) {
+    artifact = await fetchArtifact(TEST_USER_AGENT, version, '25')
+    expect(artifact.id).toBe('FE09EC0A4D9244CA834F1777BCA30041')
+    expect(artifact.checksum).toBe('efcb8984be5f72ecf8615641bec720c825a6889957f0b98d95123f563ff77c86')
+  }
+  // Test 25 LTS
+  artifact = await fetchArtifact(TEST_USER_AGENT, '25.0', '25')
+  expect(artifact.checksum).toHaveLength('b6f3dace24cf1960ec790216f4c86f00d4f43df64e4e8b548f6382f04894713f'.length)
+})
+
+test('fetch artifacts by java version', async () => {
+  let artifact = await fetchArtifactByJavaVersion(TEST_USER_AGENT, 'isBase:True', '17.0.12')
   expect(artifact.id).toBe('1C351E8F41BB8E9EE0631518000AE5F2')
   expect(artifact.checksum).toBe('b6f3dace24cf1960ec790216f4c86f00d4f43df64e4e8b548f6382f04894713f')
-  artifact = await fetchArtifact(TEST_USER_AGENT, 'isBase:True', '17')
+  artifact = await fetchArtifactByJavaVersion(TEST_USER_AGENT, 'isBase:True', '17')
   expect(artifact.checksum).toHaveLength('b6f3dace24cf1960ec790216f4c86f00d4f43df64e4e8b548f6382f04894713f'.length)
 })
 
 test('errors when downloading artifacts', async () => {
-  await expect(downloadGraalVM('invalid', '17')).rejects.toThrow(
+  await expect(downloadGraalVMViaGDSByJavaVersion('invalid', '17')).rejects.toThrow(
     'The provided "gds-token" was rejected (reason: "Invalid download token", opc-request-id: '
   )
-  await expect(downloadGraalVM('invalid', '1')).rejects.toThrow('Unable to find GraalVM for JDK 1')
+  await expect(downloadGraalVMViaGDSByJavaVersion('invalid', '1')).rejects.toThrow('Unable to find GraalVM for JDK 1')
 })
 
 test('fetch legacy artifacts', async () => {
@@ -40,13 +59,13 @@ test('fetch legacy artifacts', async () => {
 })
 
 test('errors when downloading legacy artifacts', async () => {
-  await expect(downloadGraalVMEELegacy('invalid', '22.1.0', '11')).rejects.toThrow(
+  await expect(downloadGraalVMViaGDSByJavaVersionEELegacy('invalid', '22.1.0', '11')).rejects.toThrow(
     'The provided "gds-token" was rejected (reason: "Invalid download token", opc-request-id: '
   )
-  await expect(downloadGraalVMEELegacy('invalid', '1.0.0', '11')).rejects.toThrow(
+  await expect(downloadGraalVMViaGDSByJavaVersionEELegacy('invalid', '1.0.0', '11')).rejects.toThrow(
     'Unable to find JDK11-based GraalVM EE 1.0.0'
   )
-  await expect(downloadGraalVMEELegacy('invalid', '22.1.0', '1')).rejects.toThrow(
+  await expect(downloadGraalVMViaGDSByJavaVersionEELegacy('invalid', '22.1.0', '1')).rejects.toThrow(
     'Unable to find JDK1-based GraalVM EE 22.1.0'
   )
 })

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ branding:
   color: 'blue'
 inputs:
   java-version:
-    required: true
+    required: false
     description: 'Java version. See examples of supported syntax in the README file.'
   java-package:
     description: 'The package type (jdk or jdk+fx). Currently applies to Liberica only.'

--- a/dist/cleanup.js
+++ b/dist/cleanup.js
@@ -30134,7 +30134,7 @@ function getState(name) {
     return process.env[`STATE_${name}`] || '';
 }
 
-const ACTION_VERSION = '1.5.6';
+const ACTION_VERSION = '1.6.0';
 const INPUT_GITHUB_TOKEN = 'github-token';
 const INPUT_CACHE = 'cache';
 process.platform === 'linux';

--- a/dist/main.js
+++ b/dist/main.js
@@ -38404,14 +38404,6 @@ async function getContents(repo, path) {
         path
     })).data;
 }
-async function getLastReleases(owner, repo) {
-    const octokit = getOctokit();
-    return (await octokit.request('GET /repos/{owner}/{repo}/releases', {
-        owner,
-        repo,
-        per_page: 100
-    })).data;
-}
 async function getTaggedRelease(owner, repo, tag) {
     const octokit = getOctokit();
     return (await octokit.request('GET /repos/{owner}/{repo}/releases/tags/{tag}', {
@@ -38915,23 +38907,46 @@ async function setUpGraalVMJDKCE(graalVMVersionOrDev, javaVersionOrEmpty) {
     }
     const jdkVersion = javaVersionOrEmpty.length > 0 ? javaVersionOrEmpty : '' + semverExports.coerce(graalVMVersionOrDev)?.major;
     const graalVMVersion = normalizeInnovationReleaseVersions(graalVMVersionOrDev);
-    const githubRelease = await getGraalVMCEGitHubRelease(graalVMVersion, jdkVersion);
+    const githubRelease = await getGraalVMCEGitHubRelease(graalVMVersion);
+    if (githubRelease.name?.includes(jdkVersion)) {
+        warning(`JDK version does not match GraalVM CE release. Are you sure java-version: '${jdkVersion}' is correct?`);
+    }
     const downloadUrl = findAssetDownloadUrl(githubRelease);
     const toolName = determineLegacyToolName(false, graalVMVersion, jdkVersion);
     const downloader = async () => downloadGraalVMByJavaVersionJDK(downloadUrl, graalVMVersion);
     return downloadExtractAndCacheJDK(downloader, toolName, graalVMVersion);
 }
-async function getGraalVMCEGitHubRelease(graalVMVersion, jdkVersion) {
-    if (semverExports.valid(graalVMVersion)) {
-        return await getTaggedRelease(GRAALVM_GH_USER, GRAALVM_RELEASES_REPO, GRAALVM_GRAAL_TAG_PREFIX + graalVMVersion);
+async function getGraalVMCEGitHubRelease(graalVMVersion) {
+    const releaseTag = await findReleaseTag(graalVMVersion);
+    return await getTaggedRelease(GRAALVM_GH_USER, GRAALVM_RELEASES_REPO, releaseTag);
+}
+async function findReleaseTag(graalVMVersion) {
+    let version = await findLatestGraalVMCEVersion(graalVMVersion, GRAALVM_GRAAL_TAG_PREFIX);
+    if (version !== null) {
+        return GRAALVM_GRAAL_TAG_PREFIX + version;
     }
-    const latestReleases = await getLastReleases(GRAALVM_GH_USER, GRAALVM_RELEASES_REPO);
-    for (const release of latestReleases) {
-        if (release.tag_name.includes(graalVMVersion)) {
-            return release;
+    version = await findLatestGraalVMCEVersion(graalVMVersion, GRAALVM_JDK_TAG_PREFIX);
+    if (version !== null) {
+        return GRAALVM_JDK_TAG_PREFIX + version;
+    }
+    throw new Error(`Unable to find the latest GraalVM version for '${graalVMVersion}'. Please make sure the version is set correctly. ${ERROR_HINT}`);
+}
+async function findLatestGraalVMCEVersion(graalVMVersion, tagPrefix) {
+    const matchingRefs = await getMatchingTags(GRAALVM_GH_USER, GRAALVM_RELEASES_REPO, `${tagPrefix}${graalVMVersion}`);
+    const lowestNonExistingVersion = '0.0.1';
+    let highestVersion = lowestNonExistingVersion;
+    const versionNumberStartIndex = `refs/tags/${tagPrefix}`.length;
+    for (const matchingRef of matchingRefs) {
+        const currentVersion = matchingRef.ref.substring(versionNumberStartIndex);
+        if (!semverExports.valid(currentVersion)) {
+            warning(`Skipping unexpected GraalVM CE release ${currentVersion}. ${ERROR_REQUEST}`);
+            continue;
+        }
+        if (semverExports.gt(currentVersion, highestVersion)) {
+            highestVersion = currentVersion;
         }
     }
-    throw new Error(`Unable to find GitHub release. Are you sure version: '${graalVMVersion}' and java-version: '${jdkVersion}' correct?`);
+    return highestVersion !== lowestNonExistingVersion ? highestVersion : null;
 }
 function findAssetDownloadUrl(release) {
     for (const asset of release.assets) {

--- a/dist/main.js
+++ b/dist/main.js
@@ -38756,7 +38756,7 @@ async function fetchArtifactEE(userAgent, metadata, version, javaVersion) {
         filter = `metadata=version:${version}`;
     }
     const catalogOS = IS_MACOS ? 'macos' : GRAALVM_PLATFORM;
-    const requestUrl = `${GDS_BASE}/artifacts?productId=${GDS_GRAALVM_PRODUCT_ID}&${filter}&metadata=java:jdk${javaVersion}&metadata=os:${catalogOS}&metadata=arch:${GRAALVM_ARCH}&metadata=${metadata}&status=PUBLISHED&responseFields=id&responseFields=checksum`;
+    const requestUrl = `${GDS_BASE}/artifacts?productId=${GDS_GRAALVM_PRODUCT_ID}&${filter}&metadata=edition:ee&metadata=java:jdk${javaVersion}&metadata=os:${catalogOS}&metadata=arch:${GRAALVM_ARCH}&metadata=${metadata}&status=PUBLISHED&responseFields=id&responseFields=checksum`;
     debug(`Requesting ${requestUrl}`);
     const response = await http.get(requestUrl, { accept: 'application/json' });
     if (response.message.statusCode !== 200) {

--- a/dist/main.js
+++ b/dist/main.js
@@ -30114,12 +30114,6 @@ function addPath(inputPath) {
  */
 function getInput(name, options) {
     const val = process.env[`INPUT_${name.replace(/ /g, '_').toUpperCase()}`] || '';
-    if (options && options.required && !val) {
-        throw new Error(`Input required and not supplied: ${name}`);
-    }
-    if (options && options.trimWhitespace === false) {
-        return val;
-    }
     return val.trim();
 }
 /**
@@ -38410,13 +38404,21 @@ async function getContents(repo, path) {
         path
     })).data;
 }
+async function getLastReleases(owner, repo) {
+    const octokit = getOctokit();
+    return (await octokit.request('GET /repos/{owner}/{repo}/releases', {
+        owner,
+        repo,
+        per_page: 100
+    })).data;
+}
 async function getTaggedRelease(owner, repo, tag) {
     const octokit = getOctokit();
     return (await octokit.request('GET /repos/{owner}/{repo}/releases/tags/{tag}', {
         owner,
         repo,
         tag
-    })).data; /** missing digest property */
+    })).data;
 }
 async function getMatchingTags(owner, repo, tagPrefix) {
     const octokit = getOctokit();
@@ -38671,24 +38673,64 @@ function _v4(options, buf, offset) {
     return unsafeStringify(rnds);
 }
 
-async function downloadGraalVM(gdsToken, javaVersion) {
-    const userAgent = `GraalVMGitHubAction/${ACTION_VERSION} (arch:${GRAALVM_ARCH}; os:${GRAALVM_PLATFORM}; java:${javaVersion})`;
-    const baseArtifact = await fetchArtifact(userAgent, 'isBase:True', javaVersion);
+// Support for Oracle GraalVM innovation releases
+async function downloadGraalVMViaGDS(gdsToken, graalVMVersion, jdkVersion) {
+    const userAgent = `GraalVMGitHubAction/${ACTION_VERSION} (arch:${GRAALVM_ARCH}; os:${GRAALVM_PLATFORM}; jdk:${jdkVersion})`;
+    const baseArtifact = await fetchArtifact(userAgent, graalVMVersion, jdkVersion);
     return downloadArtifact(gdsToken, userAgent, baseArtifact);
 }
-async function downloadGraalVMEELegacy(gdsToken, version, javaVersion) {
+async function fetchArtifact(userAgent, graalVMVersion, jdkVersion) {
+    const http = new HttpClient(userAgent);
+    let majorJavaVersion;
+    if (semverExports.valid(jdkVersion)) {
+        majorJavaVersion = semverExports.major(jdkVersion);
+    }
+    else {
+        majorJavaVersion = jdkVersion;
+    }
+    const catalogOS = IS_MACOS ? 'macos' : GRAALVM_PLATFORM;
+    const requestUrl = `${GDS_BASE}/artifacts?productId=${GDS_GRAALVM_PRODUCT_ID}&displayName=Oracle%20GraalVM&metadata=java:jdk${majorJavaVersion}&metadata=os:${catalogOS}&metadata=arch:${GRAALVM_ARCH}&metadata=isBase:True&status=PUBLISHED&responseFields=id&responseFields=checksum&sortBy=m:java&sortOrder=DESC`;
+    debug(`Requesting ${requestUrl}`);
+    const response = await http.get(requestUrl, { accept: 'application/json' });
+    if (response.message.statusCode !== 200) {
+        throw new Error(`Unable to find GraalVM ${graalVMVersion}. Are you sure version: '${graalVMVersion}' is correct?`);
+    }
+    const artifactResponse = JSON.parse(await response.readBody());
+    for (const artifact of artifactResponse.items) {
+        if (artifact.metadata === null) {
+            warning(`Artifact is missing metadata. ${ERROR_REQUEST}`);
+            continue;
+        }
+        for (const metadata of artifact.metadata) {
+            if (metadata.key === 'version') {
+                if (metadata.value.includes(graalVMVersion)) {
+                    return artifact;
+                }
+                break;
+            }
+        }
+    }
+    throw new Error(`Unable to find GDS artifact. Are you sure version: '${graalVMVersion}' and java-version: '${jdkVersion}' are correct?`);
+}
+// Support for GraalVM EE
+async function downloadGraalVMViaGDSByJavaVersion(gdsToken, javaVersion) {
+    const userAgent = `GraalVMGitHubAction/${ACTION_VERSION} (arch:${GRAALVM_ARCH}; os:${GRAALVM_PLATFORM}; java:${javaVersion})`;
+    const baseArtifact = await fetchArtifactByJavaVersion(userAgent, 'isBase:True', javaVersion);
+    return downloadArtifact(gdsToken, userAgent, baseArtifact);
+}
+async function downloadGraalVMViaGDSByJavaVersionEELegacy(gdsToken, version, javaVersion) {
     const userAgent = `GraalVMGitHubAction/${ACTION_VERSION} (arch:${GRAALVM_ARCH}; os:${GRAALVM_PLATFORM}; java:${javaVersion})`;
     const baseArtifact = await fetchArtifactEE(userAgent, 'isBase:True', version, javaVersion);
     return downloadArtifact(gdsToken, userAgent, baseArtifact);
 }
-async function fetchArtifact(userAgent, metadata, javaVersion) {
+async function fetchArtifactByJavaVersion(userAgent, metadata, javaVersion) {
     const http = new HttpClient(userAgent);
     let filter;
     if (javaVersion.includes('.')) {
         filter = `metadata=version:${javaVersion}`;
     }
     else {
-        filter = `sortBy=timeCreated&sortOrder=DESC&limit=1`; // latest and only one item
+        filter = `sortBy=m:java&sortOrder=DESC&limit=1`; // latest and only one item
     }
     let majorJavaVersion;
     if (semverExports.valid(javaVersion)) {
@@ -38845,9 +38887,71 @@ const ORACLE_GRAALVM_REPO_EA_BUILDS = 'oracle-graalvm-ea-builds';
 const ORACLE_GRAALVM_REPO_EA_BUILDS_LATEST_SYMBOL = 'latest-ea';
 const GRAALVM_REPO_DEV_BUILDS = 'graalvm-ce-dev-builds';
 const GRAALVM_JDK_TAG_PREFIX = 'jdk-';
-const GRAALVM_TAG_PREFIX = 'vm-';
+const GRAALVM_GRAAL_TAG_PREFIX = 'graal-';
+const GRAALVM_VM_TAG_PREFIX = 'vm-';
+// Support for GraalVM innovation releases and later
+async function setUpGraalVMJDK(graalVMVersionOrEA, javaVersionOrEmpty, gdsToken) {
+    const toolName = determineToolName$2(graalVMVersionOrEA, false);
+    if (graalVMVersionOrEA.endsWith('-ea')) {
+        // EA builds
+        const downloadUrl = await findLatestEABuildDownloadUrl(graalVMVersionOrEA);
+        const filename = basename(downloadUrl);
+        const resolvedVersion = semverExports.valid(semverExports.coerce(filename));
+        if (!resolvedVersion) {
+            throw new Error(`Unable to determine resolved version based on '${filename}'. ${ERROR_REQUEST}`);
+        }
+        const downloader = async () => downloadGraalVMByJavaVersionJDK(downloadUrl, resolvedVersion);
+        return downloadExtractAndCacheJDK(downloader, toolName, resolvedVersion);
+    }
+    const graalVMVersion = normalizeInnovationReleaseVersions(graalVMVersionOrEA);
+    const jdkVersion = javaVersionOrEmpty.length > 0 ? javaVersionOrEmpty : '' + semverExports.coerce(graalVMVersion)?.major;
+    const downloader = async () => downloadGraalVMViaGDS(gdsToken, graalVMVersion, jdkVersion);
+    return downloadExtractAndCacheJDK(downloader, toolName, graalVMVersion);
+}
+async function setUpGraalVMJDKCE(graalVMVersionOrDev, javaVersionOrEmpty) {
+    if (graalVMVersionOrDev === VERSION_DEV) {
+        // dev builds
+        return setUpGraalVMJDKDevBuild();
+    }
+    const jdkVersion = javaVersionOrEmpty.length > 0 ? javaVersionOrEmpty : '' + semverExports.coerce(graalVMVersionOrDev)?.major;
+    const graalVMVersion = normalizeInnovationReleaseVersions(graalVMVersionOrDev);
+    const githubRelease = await getGraalVMCEGitHubRelease(graalVMVersion, jdkVersion);
+    const downloadUrl = findAssetDownloadUrl(githubRelease);
+    const toolName = determineLegacyToolName(false, graalVMVersion, jdkVersion);
+    const downloader = async () => downloadGraalVMByJavaVersionJDK(downloadUrl, graalVMVersion);
+    return downloadExtractAndCacheJDK(downloader, toolName, graalVMVersion);
+}
+async function getGraalVMCEGitHubRelease(graalVMVersion, jdkVersion) {
+    if (semverExports.valid(graalVMVersion)) {
+        return await getTaggedRelease(GRAALVM_GH_USER, GRAALVM_RELEASES_REPO, GRAALVM_GRAAL_TAG_PREFIX + graalVMVersion);
+    }
+    const latestReleases = await getLastReleases(GRAALVM_GH_USER, GRAALVM_RELEASES_REPO);
+    for (const release of latestReleases) {
+        if (release.tag_name.includes(graalVMVersion)) {
+            return release;
+        }
+    }
+    throw new Error(`Unable to find GitHub release. Are you sure version: '${graalVMVersion}' and java-version: '${jdkVersion}' correct?`);
+}
+function findAssetDownloadUrl(release) {
+    for (const asset of release.assets) {
+        if (asset.name.endsWith(`_${JDK_PLATFORM}-${JDK_ARCH}_bin${GRAALVM_FILE_EXTENSION}`)) {
+            return asset.browser_download_url;
+        }
+    }
+    throw new Error(`Could not find GitHub assert. ${ERROR_REQUEST}`);
+}
+// Turns '25i1' into '25.1', keeps everything else
+function normalizeInnovationReleaseVersions(version) {
+    if (version.length === 4 && version.indexOf('i') === 2) {
+        return version.replace('i', '.');
+    }
+    else {
+        return version;
+    }
+}
 // Support for GraalVM for JDK 17 and later
-async function setUpGraalVMJDK(javaVersionOrDev, gdsToken) {
+async function setUpGraalVMJDKByJavaVersion(javaVersionOrDev, gdsToken) {
     if (javaVersionOrDev === VERSION_DEV) {
         return setUpGraalVMJDKDevBuild();
     }
@@ -38856,25 +38960,25 @@ async function setUpGraalVMJDK(javaVersionOrDev, gdsToken) {
     const toolName = determineToolName$2(javaVersion, false);
     if (javaVersionOrDev === '17' && !isTokenProvided) {
         warning('This build uses the last update of Oracle GraalVM for JDK 17 under the GFTC. More details: https://github.com/marketplace/actions/github-action-for-graalvm#notes-on-oracle-graalvm-for-jdk-17');
-        return setUpGraalVMJDK('17.0.12', gdsToken);
+        return setUpGraalVMJDKByJavaVersion('17.0.12', gdsToken);
     }
     if (IS_MACOS && JDK_ARCH === 'x64') {
         if (javaVersionOrDev === '25') {
             warning('This build uses Oracle GraalVM for JDK 25.0.1, the last available JDK 25 build for macOS Intel.');
-            return setUpGraalVMJDK('25.0.1', gdsToken);
+            return setUpGraalVMJDKByJavaVersion('25.0.1', gdsToken);
         }
         else if (javaVersionOrDev === '21') {
             warning('This build uses Oracle GraalVM for JDK 21.0.9, the last available JDK 21 build for macOS Intel.');
-            return setUpGraalVMJDK('21.0.9', gdsToken);
+            return setUpGraalVMJDKByJavaVersion('21.0.9', gdsToken);
         }
         else if (javaVersionOrDev === '17') {
             warning('This build uses Oracle GraalVM for JDK 17.0.17, the last available JDK 17 build for macOS Intel.');
-            return setUpGraalVMJDK('17.0.17', gdsToken);
+            return setUpGraalVMJDKByJavaVersion('17.0.17', gdsToken);
         }
     }
     if (isTokenProvided) {
         // Download from GDS
-        const downloader = async () => downloadGraalVM(gdsToken, javaVersion);
+        const downloader = async () => downloadGraalVMViaGDSByJavaVersion(gdsToken, javaVersion);
         return downloadExtractAndCacheJDK(downloader, toolName, javaVersion);
     }
     // Download from oracle.com
@@ -38908,7 +39012,7 @@ async function setUpGraalVMJDK(javaVersionOrDev, gdsToken) {
     else {
         downloadUrl = `${GRAALVM_DL_BASE}/${javaVersion}/latest/${downloadName}${GRAALVM_FILE_EXTENSION}`;
     }
-    const downloader = async () => downloadGraalVMJDK(downloadUrl, javaVersion);
+    const downloader = async () => downloadGraalVMByJavaVersionJDK(downloadUrl, javaVersion);
     return downloadExtractAndCacheJDK(downloader, toolName, javaVersion);
 }
 async function findLatestEABuildDownloadUrl(javaEaVersion) {
@@ -38940,13 +39044,13 @@ async function findLatestEABuildDownloadUrl(javaEaVersion) {
     }
     return `${latestVersion.download_base_url}${file.filename}`;
 }
-async function setUpGraalVMJDKCE(javaVersionOrDev) {
+async function setUpGraalVMJDKCEByJavaVersion(javaVersionOrDev) {
     if (javaVersionOrDev === VERSION_DEV) {
         return setUpGraalVMJDKDevBuild();
     }
     if (IS_MACOS && JDK_ARCH === 'x64' && javaVersionOrDev === '25') {
         warning('This build uses GraalVM CE for JDK 25.0.1, the last available JDK 25 build for macOS Intel.');
-        return setUpGraalVMJDKCE('25.0.1');
+        return setUpGraalVMJDKCEByJavaVersion('25.0.1');
     }
     let javaVersion = javaVersionOrDev;
     if (!javaVersion.includes('.')) {
@@ -38957,7 +39061,7 @@ async function setUpGraalVMJDKCE(javaVersionOrDev) {
     }
     const toolName = determineToolName$2(javaVersion, true);
     const downloadUrl = `${GRAALVM_CE_DL_BASE}/jdk-${javaVersion}/${toolName}${GRAALVM_FILE_EXTENSION}`;
-    const downloader = async () => downloadGraalVMJDK(downloadUrl, javaVersion);
+    const downloader = async () => downloadGraalVMByJavaVersionJDK(downloadUrl, javaVersion);
     return downloadExtractAndCacheJDK(downloader, toolName, javaVersion);
 }
 async function findLatestGraalVMJDKCEJavaVersion(majorJavaVersion) {
@@ -38979,7 +39083,7 @@ async function findLatestGraalVMJDKCEJavaVersion(majorJavaVersion) {
 function determineToolName$2(javaVersion, isCommunity) {
     return `graalvm${isCommunity ? '-community' : ''}-jdk-${javaVersion}_${JDK_PLATFORM}-${JDK_ARCH}_bin`;
 }
-async function downloadGraalVMJDK(downloadUrl, javaVersion) {
+async function downloadGraalVMByJavaVersionJDK(downloadUrl, javaVersion) {
     try {
         return await downloadFile(downloadUrl);
     }
@@ -39024,26 +39128,26 @@ async function setUpGraalVMLatest_22_X(gdsToken, javaVersion) {
     if (gdsToken.length > 0) {
         return setUpGraalVMRelease(gdsToken, lockedVersion, javaVersion);
     }
-    const latestRelease = await getTaggedRelease(GRAALVM_GH_USER, GRAALVM_RELEASES_REPO, GRAALVM_TAG_PREFIX + lockedVersion);
+    const latestRelease = await getTaggedRelease(GRAALVM_GH_USER, GRAALVM_RELEASES_REPO, GRAALVM_VM_TAG_PREFIX + lockedVersion);
     const version = findGraalVMVersion(latestRelease);
     return setUpGraalVMRelease(gdsToken, version, javaVersion);
 }
 function findGraalVMVersion(release) {
     const tag_name = release.tag_name;
-    if (!tag_name.startsWith(GRAALVM_TAG_PREFIX)) {
+    if (!tag_name.startsWith(GRAALVM_VM_TAG_PREFIX)) {
         throw new Error(`Could not find latest GraalVM release: ${tag_name}`);
     }
-    return tag_name.substring(GRAALVM_TAG_PREFIX.length, tag_name.length);
+    return tag_name.substring(GRAALVM_VM_TAG_PREFIX.length, tag_name.length);
 }
 async function setUpGraalVMRelease(gdsToken, version, javaVersion) {
     const isEE = gdsToken.length > 0;
     const toolName = determineLegacyToolName(isEE, version, javaVersion);
     let downloader;
     if (isEE) {
-        downloader = async () => downloadGraalVMEELegacy(gdsToken, version, javaVersion);
+        downloader = async () => downloadGraalVMViaGDSByJavaVersionEELegacy(gdsToken, version, javaVersion);
     }
     else {
-        downloader = async () => downloadGraalVMCELegacy(version, javaVersion);
+        downloader = async () => downloadGraalVMByJavaVersionCELegacy(version, javaVersion);
     }
     return downloadExtractAndCacheJDK(downloader, toolName, version);
 }
@@ -39070,9 +39174,9 @@ function determineLegacyToolName(isEE, version, javaVersion) {
     const infix = isEE ? 'ee' : version === VERSION_DEV ? 'community' : 'ce';
     return `graalvm-${infix}-java${javaVersion}-${GRAALVM_PLATFORM}`;
 }
-async function downloadGraalVMCELegacy(version, javaVersion) {
+async function downloadGraalVMByJavaVersionCELegacy(version, javaVersion) {
     const graalVMIdentifier = determineGraalVMLegacyIdentifier(false, version, javaVersion);
-    const downloadUrl = `${GRAALVM_CE_DL_BASE}/${GRAALVM_TAG_PREFIX}${version}/${graalVMIdentifier}${GRAALVM_FILE_EXTENSION}`;
+    const downloadUrl = `${GRAALVM_CE_DL_BASE}/${GRAALVM_VM_TAG_PREFIX}${version}/${graalVMIdentifier}${GRAALVM_FILE_EXTENSION}`;
     try {
         return await downloadFile(downloadUrl);
     }
@@ -83660,7 +83764,7 @@ function isFeatureEnabled() {
 
 async function run() {
     try {
-        const javaVersion = getInput(INPUT_JAVA_VERSION, { required: true });
+        const javaVersion = getInput(INPUT_JAVA_VERSION);
         const javaPackage = getInput(INPUT_JAVA_PACKAGE);
         const distribution = getInput(INPUT_DISTRIBUTION);
         const graalVMVersion = getInput(INPUT_VERSION);
@@ -83688,10 +83792,26 @@ async function run() {
             }
             switch (distribution) {
                 case DISTRIBUTION_GRAALVM:
-                    graalVMHome = await setUpGraalVMJDK(javaVersion, gdsToken);
+                    if (graalVMVersion.length > 0) {
+                        graalVMHome = await setUpGraalVMJDK(graalVMVersion, javaVersion, gdsToken);
+                    }
+                    else if (javaVersion.length > 0) {
+                        graalVMHome = await setUpGraalVMJDKByJavaVersion(javaVersion, gdsToken);
+                    }
+                    else {
+                        throw new Error(`Please provide either 'version' or 'java-version' to select a GraalVM distribution`);
+                    }
                     break;
                 case DISTRIBUTION_GRAALVM_COMMUNITY:
-                    graalVMHome = await setUpGraalVMJDKCE(javaVersion);
+                    if (graalVMVersion.length > 0) {
+                        graalVMHome = await setUpGraalVMJDKCE(graalVMVersion, javaVersion);
+                    }
+                    else if (javaVersion.length > 0) {
+                        graalVMHome = await setUpGraalVMJDKCEByJavaVersion(javaVersion);
+                    }
+                    else {
+                        throw new Error(`Please provide either 'version' or 'java-version' to select a GraalVM distribution`);
+                    }
                     break;
                 case DISTRIBUTION_MANDREL:
                     graalVMHome = await setUpMandrel(graalVMVersion, javaVersion);
@@ -83706,7 +83826,7 @@ async function run() {
                     }
                     else {
                         info(`This build is using the new Oracle GraalVM. To select a specific distribution, use the 'distribution' option (see https://github.com/graalvm/setup-graalvm/tree/main#options).`);
-                        graalVMHome = await setUpGraalVMJDK(javaVersion, gdsToken);
+                        graalVMHome = await setUpGraalVMJDKByJavaVersion(javaVersion, gdsToken);
                     }
                     break;
                 default:
@@ -83720,7 +83840,7 @@ async function run() {
                     if (javaVersion.startsWith('17') ||
                         (coercedJavaVersion !== null && semverExports.gte(coercedJavaVersion, '20.0.0'))) {
                         info(`This build is using the new Oracle GraalVM. To select a specific distribution, use the 'distribution' option (see https://github.com/graalvm/setup-graalvm/tree/main#options).`);
-                        graalVMHome = await setUpGraalVMJDK(javaVersion, gdsToken);
+                        graalVMHome = await setUpGraalVMJDKByJavaVersion(javaVersion, gdsToken);
                     }
                     else {
                         graalVMHome = await setUpGraalVMLatest_22_X(gdsToken, javaVersion);
@@ -83732,7 +83852,7 @@ async function run() {
                     }
                     if (coercedJavaVersion !== null && !semverExports.gte(coercedJavaVersion, '21.0.0')) {
                         warning(`GraalVM dev builds are only available for JDK 21. This build is now using a stable release of GraalVM for JDK ${javaVersion}.`);
-                        graalVMHome = await setUpGraalVMJDK(javaVersion, gdsToken);
+                        graalVMHome = await setUpGraalVMJDKByJavaVersion(javaVersion, gdsToken);
                     }
                     else {
                         graalVMHome = await setUpGraalVMJDKDevBuild();

--- a/dist/main.js
+++ b/dist/main.js
@@ -51,7 +51,7 @@ import require$$1$5 from 'tty';
 import { createHmac } from 'node:crypto';
 import fs$1 from 'node:fs';
 
-const ACTION_VERSION = '1.5.6';
+const ACTION_VERSION = '1.6.0';
 const INPUT_VERSION = 'version';
 const INPUT_GDS_TOKEN = 'gds-token';
 const INPUT_JAVA_VERSION = 'java-version';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "setup-graalvm",
-  "version": "1.5.6",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "setup-graalvm",
-      "version": "1.5.6",
+      "version": "1.6.0",
       "license": "UPL",
       "dependencies": {
         "@actions/cache": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "setup-graalvm",
   "author": "GraalVM Community",
   "description": "GitHub Action for GraalVM",
-  "version": "1.5.6",
+  "version": "1.6.0",
   "type": "module",
   "private": true,
   "repository": {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -56,8 +56,6 @@ export const ERROR_HINT =
 export type LatestReleaseResponseData =
   otypes.Endpoints['GET /repos/{owner}/{repo}/releases/latest']['response']['data']
 
-export type ListReleasesResponseData = otypes.Endpoints['GET /repos/{owner}/{repo}/releases']['response']['data']
-
 export type MatchingRefsResponseData =
   otypes.Endpoints['GET /repos/{owner}/{repo}/git/matching-refs/{ref}']['response']['data']
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -56,6 +56,8 @@ export const ERROR_HINT =
 export type LatestReleaseResponseData =
   otypes.Endpoints['GET /repos/{owner}/{repo}/releases/latest']['response']['data']
 
+export type ListReleasesResponseData = otypes.Endpoints['GET /repos/{owner}/{repo}/releases']['response']['data']
+
 export type MatchingRefsResponseData =
   otypes.Endpoints['GET /repos/{owner}/{repo}/git/matching-refs/{ref}']['response']['data']
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,6 @@
 import * as otypes from '@octokit/types'
 
-export const ACTION_VERSION = '1.5.6'
+export const ACTION_VERSION = '1.6.0'
 
 export const INPUT_VERSION = 'version'
 export const INPUT_GDS_TOKEN = 'gds-token'

--- a/src/gds.ts
+++ b/src/gds.ts
@@ -20,6 +20,13 @@ interface GDSArtifactsResponse {
 interface GDSArtifact {
   readonly id: string
   readonly checksum: string
+  readonly metadata: GDSMetadata[] | null
+}
+
+interface GDSMetadata {
+  readonly key: string
+  readonly value: string
+  readonly description: string
 }
 
 interface GDSErrorResponse {
@@ -27,26 +34,90 @@ interface GDSErrorResponse {
   readonly message: string
 }
 
-export async function downloadGraalVM(gdsToken: string, javaVersion: string): Promise<string> {
-  const userAgent = `GraalVMGitHubAction/${c.ACTION_VERSION} (arch:${c.GRAALVM_ARCH}; os:${c.GRAALVM_PLATFORM}; java:${javaVersion})`
-  const baseArtifact = await fetchArtifact(userAgent, 'isBase:True', javaVersion)
+// Support for Oracle GraalVM innovation releases
+
+export async function downloadGraalVMViaGDS(
+  gdsToken: string,
+  graalVMVersion: string,
+  jdkVersion: string
+): Promise<string> {
+  const userAgent = `GraalVMGitHubAction/${c.ACTION_VERSION} (arch:${c.GRAALVM_ARCH}; os:${c.GRAALVM_PLATFORM}; jdk:${jdkVersion})`
+  const baseArtifact = await fetchArtifact(userAgent, graalVMVersion, jdkVersion)
   return downloadArtifact(gdsToken, userAgent, baseArtifact)
 }
 
-export async function downloadGraalVMEELegacy(gdsToken: string, version: string, javaVersion: string): Promise<string> {
+export async function fetchArtifact(
+  userAgent: string,
+  graalVMVersion: string,
+  jdkVersion: string
+): Promise<GDSArtifact> {
+  const http = new httpClient.HttpClient(userAgent)
+
+  let majorJavaVersion
+  if (semver.valid(jdkVersion)) {
+    majorJavaVersion = semver.major(jdkVersion)
+  } else {
+    majorJavaVersion = jdkVersion
+  }
+
+  const catalogOS = c.IS_MACOS ? 'macos' : c.GRAALVM_PLATFORM
+  const requestUrl = `${c.GDS_BASE}/artifacts?productId=${c.GDS_GRAALVM_PRODUCT_ID}&displayName=Oracle%20GraalVM&metadata=java:jdk${majorJavaVersion}&metadata=os:${catalogOS}&metadata=arch:${c.GRAALVM_ARCH}&metadata=isBase:True&status=PUBLISHED&responseFields=id&responseFields=checksum&sortBy=m:java&sortOrder=DESC`
+  core.debug(`Requesting ${requestUrl}`)
+  const response = await http.get(requestUrl, { accept: 'application/json' })
+  if (response.message.statusCode !== 200) {
+    throw new Error(`Unable to find GraalVM ${graalVMVersion}. Are you sure version: '${graalVMVersion}' is correct?`)
+  }
+  const artifactResponse = JSON.parse(await response.readBody()) as GDSArtifactsResponse
+
+  for (const artifact of artifactResponse.items) {
+    if (artifact.metadata === null) {
+      core.warning(`Artifact is missing metadata. ${c.ERROR_REQUEST}`)
+      continue
+    }
+    for (const metadata of artifact.metadata) {
+      if (metadata.key === 'version') {
+        if (metadata.value.includes(graalVMVersion)) {
+          return artifact
+        }
+        break
+      }
+    }
+  }
+  throw new Error(
+    `Unable to find GDS artifact. Are you sure version: '${graalVMVersion}' and java-version: '${jdkVersion}' are correct?`
+  )
+}
+
+// Support for GraalVM EE
+
+export async function downloadGraalVMViaGDSByJavaVersion(gdsToken: string, javaVersion: string): Promise<string> {
+  const userAgent = `GraalVMGitHubAction/${c.ACTION_VERSION} (arch:${c.GRAALVM_ARCH}; os:${c.GRAALVM_PLATFORM}; java:${javaVersion})`
+  const baseArtifact = await fetchArtifactByJavaVersion(userAgent, 'isBase:True', javaVersion)
+  return downloadArtifact(gdsToken, userAgent, baseArtifact)
+}
+
+export async function downloadGraalVMViaGDSByJavaVersionEELegacy(
+  gdsToken: string,
+  version: string,
+  javaVersion: string
+): Promise<string> {
   const userAgent = `GraalVMGitHubAction/${c.ACTION_VERSION} (arch:${c.GRAALVM_ARCH}; os:${c.GRAALVM_PLATFORM}; java:${javaVersion})`
   const baseArtifact = await fetchArtifactEE(userAgent, 'isBase:True', version, javaVersion)
   return downloadArtifact(gdsToken, userAgent, baseArtifact)
 }
 
-export async function fetchArtifact(userAgent: string, metadata: string, javaVersion: string): Promise<GDSArtifact> {
+export async function fetchArtifactByJavaVersion(
+  userAgent: string,
+  metadata: string,
+  javaVersion: string
+): Promise<GDSArtifact> {
   const http = new httpClient.HttpClient(userAgent)
 
   let filter
   if (javaVersion.includes('.')) {
     filter = `metadata=version:${javaVersion}`
   } else {
-    filter = `sortBy=timeCreated&sortOrder=DESC&limit=1` // latest and only one item
+    filter = `sortBy=m:java&sortOrder=DESC&limit=1` // latest and only one item
   }
 
   let majorJavaVersion

--- a/src/gds.ts
+++ b/src/gds.ts
@@ -163,7 +163,7 @@ export async function fetchArtifactEE(
   }
 
   const catalogOS = c.IS_MACOS ? 'macos' : c.GRAALVM_PLATFORM
-  const requestUrl = `${c.GDS_BASE}/artifacts?productId=${c.GDS_GRAALVM_PRODUCT_ID}&${filter}&metadata=java:jdk${javaVersion}&metadata=os:${catalogOS}&metadata=arch:${c.GRAALVM_ARCH}&metadata=${metadata}&status=PUBLISHED&responseFields=id&responseFields=checksum`
+  const requestUrl = `${c.GDS_BASE}/artifacts?productId=${c.GDS_GRAALVM_PRODUCT_ID}&${filter}&metadata=edition:ee&metadata=java:jdk${javaVersion}&metadata=os:${catalogOS}&metadata=arch:${c.GRAALVM_ARCH}&metadata=${metadata}&status=PUBLISHED&responseFields=id&responseFields=checksum`
   core.debug(`Requesting ${requestUrl}`)
   const response = await http.get(requestUrl, { accept: 'application/json' })
   if (response.message.statusCode !== 200) {

--- a/src/graalvm.ts
+++ b/src/graalvm.ts
@@ -8,9 +8,14 @@ import {
   getContents,
   getLatestRelease,
   getMatchingTags,
-  getTaggedRelease
+  getTaggedRelease,
+  getLastReleases
 } from './utils.js'
-import { downloadGraalVM, downloadGraalVMEELegacy } from './gds.js'
+import {
+  downloadGraalVMViaGDS,
+  downloadGraalVMViaGDSByJavaVersion,
+  downloadGraalVMViaGDSByJavaVersionEELegacy
+} from './gds.js'
 import { basename } from 'path'
 
 const GRAALVM_DL_BASE = 'https://download.oracle.com/graalvm'
@@ -19,11 +24,88 @@ const ORACLE_GRAALVM_REPO_EA_BUILDS = 'oracle-graalvm-ea-builds'
 const ORACLE_GRAALVM_REPO_EA_BUILDS_LATEST_SYMBOL = 'latest-ea'
 const GRAALVM_REPO_DEV_BUILDS = 'graalvm-ce-dev-builds'
 const GRAALVM_JDK_TAG_PREFIX = 'jdk-'
-const GRAALVM_TAG_PREFIX = 'vm-'
+const GRAALVM_GRAAL_TAG_PREFIX = 'graal-'
+const GRAALVM_VM_TAG_PREFIX = 'vm-'
+
+// Support for GraalVM innovation releases and later
+
+export async function setUpGraalVMJDK(
+  graalVMVersionOrEA: string,
+  javaVersionOrEmpty: string,
+  gdsToken: string
+): Promise<string> {
+  const toolName = determineToolName(graalVMVersionOrEA, false)
+  if (graalVMVersionOrEA.endsWith('-ea')) {
+    // EA builds
+    const downloadUrl = await findLatestEABuildDownloadUrl(graalVMVersionOrEA)
+    const filename = basename(downloadUrl)
+    const resolvedVersion = semver.valid(semver.coerce(filename))
+    if (!resolvedVersion) {
+      throw new Error(`Unable to determine resolved version based on '${filename}'. ${c.ERROR_REQUEST}`)
+    }
+    const downloader = async () => downloadGraalVMByJavaVersionJDK(downloadUrl, resolvedVersion)
+    return downloadExtractAndCacheJDK(downloader, toolName, resolvedVersion)
+  }
+  const graalVMVersion = normalizeInnovationReleaseVersions(graalVMVersionOrEA)
+  const jdkVersion = javaVersionOrEmpty.length > 0 ? javaVersionOrEmpty : '' + semver.coerce(graalVMVersion)?.major
+  const downloader = async () => downloadGraalVMViaGDS(gdsToken, graalVMVersion, jdkVersion)
+  return downloadExtractAndCacheJDK(downloader, toolName, graalVMVersion)
+}
+
+export async function setUpGraalVMJDKCE(graalVMVersionOrDev: string, javaVersionOrEmpty: string): Promise<string> {
+  if (graalVMVersionOrDev === c.VERSION_DEV) {
+    // dev builds
+    return setUpGraalVMJDKDevBuild()
+  }
+  const jdkVersion = javaVersionOrEmpty.length > 0 ? javaVersionOrEmpty : '' + semver.coerce(graalVMVersionOrDev)?.major
+  const graalVMVersion = normalizeInnovationReleaseVersions(graalVMVersionOrDev)
+
+  const githubRelease = await getGraalVMCEGitHubRelease(graalVMVersion, jdkVersion)
+  const downloadUrl = findAssetDownloadUrl(githubRelease)
+  const toolName = determineLegacyToolName(false, graalVMVersion, jdkVersion)
+  const downloader = async () => downloadGraalVMByJavaVersionJDK(downloadUrl, graalVMVersion)
+  return downloadExtractAndCacheJDK(downloader, toolName, graalVMVersion)
+}
+
+async function getGraalVMCEGitHubRelease(
+  graalVMVersion: string,
+  jdkVersion: string
+): Promise<c.LatestReleaseResponseData> {
+  if (semver.valid(graalVMVersion)) {
+    return await getTaggedRelease(c.GRAALVM_GH_USER, c.GRAALVM_RELEASES_REPO, GRAALVM_GRAAL_TAG_PREFIX + graalVMVersion)
+  }
+  const latestReleases = await getLastReleases(c.GRAALVM_GH_USER, c.GRAALVM_RELEASES_REPO)
+  for (const release of latestReleases) {
+    if (release.tag_name.includes(graalVMVersion)) {
+      return release
+    }
+  }
+  throw new Error(
+    `Unable to find GitHub release. Are you sure version: '${graalVMVersion}' and java-version: '${jdkVersion}' correct?`
+  )
+}
+
+function findAssetDownloadUrl(release: c.LatestReleaseResponseData) {
+  for (const asset of release.assets) {
+    if (asset.name.endsWith(`_${c.JDK_PLATFORM}-${c.JDK_ARCH}_bin${c.GRAALVM_FILE_EXTENSION}`)) {
+      return asset.browser_download_url
+    }
+  }
+  throw new Error(`Could not find GitHub assert. ${c.ERROR_REQUEST}`)
+}
+
+// Turns '25i1' into '25.1', keeps everything else
+function normalizeInnovationReleaseVersions(version: string): string {
+  if (version.length === 4 && version.indexOf('i') === 2) {
+    return version.replace('i', '.')
+  } else {
+    return version
+  }
+}
 
 // Support for GraalVM for JDK 17 and later
 
-export async function setUpGraalVMJDK(javaVersionOrDev: string, gdsToken: string): Promise<string> {
+export async function setUpGraalVMJDKByJavaVersion(javaVersionOrDev: string, gdsToken: string): Promise<string> {
   if (javaVersionOrDev === c.VERSION_DEV) {
     return setUpGraalVMJDKDevBuild()
   }
@@ -34,23 +116,23 @@ export async function setUpGraalVMJDK(javaVersionOrDev: string, gdsToken: string
     core.warning(
       'This build uses the last update of Oracle GraalVM for JDK 17 under the GFTC. More details: https://github.com/marketplace/actions/github-action-for-graalvm#notes-on-oracle-graalvm-for-jdk-17'
     )
-    return setUpGraalVMJDK('17.0.12', gdsToken)
+    return setUpGraalVMJDKByJavaVersion('17.0.12', gdsToken)
   }
   if (c.IS_MACOS && c.JDK_ARCH === 'x64') {
     if (javaVersionOrDev === '25') {
       core.warning('This build uses Oracle GraalVM for JDK 25.0.1, the last available JDK 25 build for macOS Intel.')
-      return setUpGraalVMJDK('25.0.1', gdsToken)
+      return setUpGraalVMJDKByJavaVersion('25.0.1', gdsToken)
     } else if (javaVersionOrDev === '21') {
       core.warning('This build uses Oracle GraalVM for JDK 21.0.9, the last available JDK 21 build for macOS Intel.')
-      return setUpGraalVMJDK('21.0.9', gdsToken)
+      return setUpGraalVMJDKByJavaVersion('21.0.9', gdsToken)
     } else if (javaVersionOrDev === '17') {
       core.warning('This build uses Oracle GraalVM for JDK 17.0.17, the last available JDK 17 build for macOS Intel.')
-      return setUpGraalVMJDK('17.0.17', gdsToken)
+      return setUpGraalVMJDKByJavaVersion('17.0.17', gdsToken)
     }
   }
   if (isTokenProvided) {
     // Download from GDS
-    const downloader = async () => downloadGraalVM(gdsToken, javaVersion)
+    const downloader = async () => downloadGraalVMViaGDSByJavaVersion(gdsToken, javaVersion)
     return downloadExtractAndCacheJDK(downloader, toolName, javaVersion)
   }
   // Download from oracle.com
@@ -83,7 +165,7 @@ export async function setUpGraalVMJDK(javaVersionOrDev: string, gdsToken: string
   } else {
     downloadUrl = `${GRAALVM_DL_BASE}/${javaVersion}/latest/${downloadName}${c.GRAALVM_FILE_EXTENSION}`
   }
-  const downloader = async () => downloadGraalVMJDK(downloadUrl, javaVersion)
+  const downloader = async () => downloadGraalVMByJavaVersionJDK(downloadUrl, javaVersion)
   return downloadExtractAndCacheJDK(downloader, toolName, javaVersion)
 }
 
@@ -118,13 +200,13 @@ export async function findLatestEABuildDownloadUrl(javaEaVersion: string): Promi
   return `${latestVersion.download_base_url}${file.filename}`
 }
 
-export async function setUpGraalVMJDKCE(javaVersionOrDev: string): Promise<string> {
+export async function setUpGraalVMJDKCEByJavaVersion(javaVersionOrDev: string): Promise<string> {
   if (javaVersionOrDev === c.VERSION_DEV) {
     return setUpGraalVMJDKDevBuild()
   }
   if (c.IS_MACOS && c.JDK_ARCH === 'x64' && javaVersionOrDev === '25') {
     core.warning('This build uses GraalVM CE for JDK 25.0.1, the last available JDK 25 build for macOS Intel.')
-    return setUpGraalVMJDKCE('25.0.1')
+    return setUpGraalVMJDKCEByJavaVersion('25.0.1')
   }
   let javaVersion = javaVersionOrDev
   if (!javaVersion.includes('.')) {
@@ -137,7 +219,7 @@ export async function setUpGraalVMJDKCE(javaVersionOrDev: string): Promise<strin
   }
   const toolName = determineToolName(javaVersion, true)
   const downloadUrl = `${GRAALVM_CE_DL_BASE}/jdk-${javaVersion}/${toolName}${c.GRAALVM_FILE_EXTENSION}`
-  const downloader = async () => downloadGraalVMJDK(downloadUrl, javaVersion)
+  const downloader = async () => downloadGraalVMByJavaVersionJDK(downloadUrl, javaVersion)
   return downloadExtractAndCacheJDK(downloader, toolName, javaVersion)
 }
 
@@ -168,7 +250,7 @@ function determineToolName(javaVersion: string, isCommunity: boolean) {
   return `graalvm${isCommunity ? '-community' : ''}-jdk-${javaVersion}_${c.JDK_PLATFORM}-${c.JDK_ARCH}_bin`
 }
 
-async function downloadGraalVMJDK(downloadUrl: string, javaVersion: string): Promise<string> {
+async function downloadGraalVMByJavaVersionJDK(downloadUrl: string, javaVersion: string): Promise<string> {
   try {
     return await downloadFile(downloadUrl)
   } catch (error) {
@@ -224,7 +306,7 @@ export async function setUpGraalVMLatest_22_X(gdsToken: string, javaVersion: str
   const latestRelease = await getTaggedRelease(
     c.GRAALVM_GH_USER,
     c.GRAALVM_RELEASES_REPO,
-    GRAALVM_TAG_PREFIX + lockedVersion
+    GRAALVM_VM_TAG_PREFIX + lockedVersion
   )
   const version = findGraalVMVersion(latestRelease)
   return setUpGraalVMRelease(gdsToken, version, javaVersion)
@@ -232,10 +314,10 @@ export async function setUpGraalVMLatest_22_X(gdsToken: string, javaVersion: str
 
 export function findGraalVMVersion(release: c.LatestReleaseResponseData) {
   const tag_name = release.tag_name
-  if (!tag_name.startsWith(GRAALVM_TAG_PREFIX)) {
+  if (!tag_name.startsWith(GRAALVM_VM_TAG_PREFIX)) {
     throw new Error(`Could not find latest GraalVM release: ${tag_name}`)
   }
-  return tag_name.substring(GRAALVM_TAG_PREFIX.length, tag_name.length)
+  return tag_name.substring(GRAALVM_VM_TAG_PREFIX.length, tag_name.length)
 }
 
 export async function setUpGraalVMRelease(gdsToken: string, version: string, javaVersion: string): Promise<string> {
@@ -243,9 +325,9 @@ export async function setUpGraalVMRelease(gdsToken: string, version: string, jav
   const toolName = determineLegacyToolName(isEE, version, javaVersion)
   let downloader: () => Promise<string>
   if (isEE) {
-    downloader = async () => downloadGraalVMEELegacy(gdsToken, version, javaVersion)
+    downloader = async () => downloadGraalVMViaGDSByJavaVersionEELegacy(gdsToken, version, javaVersion)
   } else {
-    downloader = async () => downloadGraalVMCELegacy(version, javaVersion)
+    downloader = async () => downloadGraalVMByJavaVersionCELegacy(version, javaVersion)
   }
   return downloadExtractAndCacheJDK(downloader, toolName, version)
 }
@@ -279,9 +361,9 @@ function determineLegacyToolName(isEE: boolean, version: string, javaVersion: st
   return `graalvm-${infix}-java${javaVersion}-${c.GRAALVM_PLATFORM}`
 }
 
-async function downloadGraalVMCELegacy(version: string, javaVersion: string): Promise<string> {
+async function downloadGraalVMByJavaVersionCELegacy(version: string, javaVersion: string): Promise<string> {
   const graalVMIdentifier = determineGraalVMLegacyIdentifier(false, version, javaVersion)
-  const downloadUrl = `${GRAALVM_CE_DL_BASE}/${GRAALVM_TAG_PREFIX}${version}/${graalVMIdentifier}${c.GRAALVM_FILE_EXTENSION}`
+  const downloadUrl = `${GRAALVM_CE_DL_BASE}/${GRAALVM_VM_TAG_PREFIX}${version}/${graalVMIdentifier}${c.GRAALVM_FILE_EXTENSION}`
   try {
     return await downloadFile(downloadUrl)
   } catch (error) {

--- a/src/graalvm.ts
+++ b/src/graalvm.ts
@@ -8,8 +8,7 @@ import {
   getContents,
   getLatestRelease,
   getMatchingTags,
-  getTaggedRelease,
-  getLastReleases
+  getTaggedRelease
 } from './utils.js'
 import {
   downloadGraalVMViaGDS,
@@ -60,29 +59,57 @@ export async function setUpGraalVMJDKCE(graalVMVersionOrDev: string, javaVersion
   const jdkVersion = javaVersionOrEmpty.length > 0 ? javaVersionOrEmpty : '' + semver.coerce(graalVMVersionOrDev)?.major
   const graalVMVersion = normalizeInnovationReleaseVersions(graalVMVersionOrDev)
 
-  const githubRelease = await getGraalVMCEGitHubRelease(graalVMVersion, jdkVersion)
+  const githubRelease = await getGraalVMCEGitHubRelease(graalVMVersion)
+  if (githubRelease.name?.includes(jdkVersion)) {
+    core.warning(
+      `JDK version does not match GraalVM CE release. Are you sure java-version: '${jdkVersion}' is correct?`
+    )
+  }
   const downloadUrl = findAssetDownloadUrl(githubRelease)
   const toolName = determineLegacyToolName(false, graalVMVersion, jdkVersion)
   const downloader = async () => downloadGraalVMByJavaVersionJDK(downloadUrl, graalVMVersion)
   return downloadExtractAndCacheJDK(downloader, toolName, graalVMVersion)
 }
 
-async function getGraalVMCEGitHubRelease(
-  graalVMVersion: string,
-  jdkVersion: string
-): Promise<c.LatestReleaseResponseData> {
-  if (semver.valid(graalVMVersion)) {
-    return await getTaggedRelease(c.GRAALVM_GH_USER, c.GRAALVM_RELEASES_REPO, GRAALVM_GRAAL_TAG_PREFIX + graalVMVersion)
+async function getGraalVMCEGitHubRelease(graalVMVersion: string): Promise<c.LatestReleaseResponseData> {
+  const releaseTag = await findReleaseTag(graalVMVersion)
+  return await getTaggedRelease(c.GRAALVM_GH_USER, c.GRAALVM_RELEASES_REPO, releaseTag)
+}
+
+async function findReleaseTag(graalVMVersion: string) {
+  let version = await findLatestGraalVMCEVersion(graalVMVersion, GRAALVM_GRAAL_TAG_PREFIX)
+  if (version !== null) {
+    return GRAALVM_GRAAL_TAG_PREFIX + version
   }
-  const latestReleases = await getLastReleases(c.GRAALVM_GH_USER, c.GRAALVM_RELEASES_REPO)
-  for (const release of latestReleases) {
-    if (release.tag_name.includes(graalVMVersion)) {
-      return release
-    }
+  version = await findLatestGraalVMCEVersion(graalVMVersion, GRAALVM_JDK_TAG_PREFIX)
+  if (version !== null) {
+    return GRAALVM_JDK_TAG_PREFIX + version
   }
   throw new Error(
-    `Unable to find GitHub release. Are you sure version: '${graalVMVersion}' and java-version: '${jdkVersion}' correct?`
+    `Unable to find the latest GraalVM version for '${graalVMVersion}'. Please make sure the version is set correctly. ${c.ERROR_HINT}`
   )
+}
+
+export async function findLatestGraalVMCEVersion(graalVMVersion: string, tagPrefix: string): Promise<string | null> {
+  const matchingRefs = await getMatchingTags(
+    c.GRAALVM_GH_USER,
+    c.GRAALVM_RELEASES_REPO,
+    `${tagPrefix}${graalVMVersion}`
+  )
+  const lowestNonExistingVersion = '0.0.1'
+  let highestVersion = lowestNonExistingVersion
+  const versionNumberStartIndex = `refs/tags/${tagPrefix}`.length
+  for (const matchingRef of matchingRefs) {
+    const currentVersion = matchingRef.ref.substring(versionNumberStartIndex)
+    if (!semver.valid(currentVersion)) {
+      core.warning(`Skipping unexpected GraalVM CE release ${currentVersion}. ${c.ERROR_REQUEST}`)
+      continue
+    }
+    if (semver.gt(currentVersion, highestVersion)) {
+      highestVersion = currentVersion
+    }
+  }
+  return highestVersion !== lowestNonExistingVersion ? highestVersion : null
 }
 
 function findAssetDownloadUrl(release: c.LatestReleaseResponseData) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,7 @@ import { setUpSBOMSupport } from './features/sbom.js'
 
 async function run(): Promise<void> {
   try {
-    const javaVersion = core.getInput(c.INPUT_JAVA_VERSION, { required: true })
+    const javaVersion = core.getInput(c.INPUT_JAVA_VERSION)
     const javaPackage = core.getInput(c.INPUT_JAVA_PACKAGE)
     const distribution = core.getInput(c.INPUT_DISTRIBUTION)
     const graalVMVersion = core.getInput(c.INPUT_VERSION)
@@ -50,10 +50,22 @@ async function run(): Promise<void> {
       }
       switch (distribution) {
         case c.DISTRIBUTION_GRAALVM:
-          graalVMHome = await graalvm.setUpGraalVMJDK(javaVersion, gdsToken)
+          if (graalVMVersion.length > 0) {
+            graalVMHome = await graalvm.setUpGraalVMJDK(graalVMVersion, javaVersion, gdsToken)
+          } else if (javaVersion.length > 0) {
+            graalVMHome = await graalvm.setUpGraalVMJDKByJavaVersion(javaVersion, gdsToken)
+          } else {
+            throw new Error(`Please provide either 'version' or 'java-version' to select a GraalVM distribution`)
+          }
           break
         case c.DISTRIBUTION_GRAALVM_COMMUNITY:
-          graalVMHome = await graalvm.setUpGraalVMJDKCE(javaVersion)
+          if (graalVMVersion.length > 0) {
+            graalVMHome = await graalvm.setUpGraalVMJDKCE(graalVMVersion, javaVersion)
+          } else if (javaVersion.length > 0) {
+            graalVMHome = await graalvm.setUpGraalVMJDKCEByJavaVersion(javaVersion)
+          } else {
+            throw new Error(`Please provide either 'version' or 'java-version' to select a GraalVM distribution`)
+          }
           break
         case c.DISTRIBUTION_MANDREL:
           graalVMHome = await setUpMandrel(graalVMVersion, javaVersion)
@@ -71,7 +83,7 @@ async function run(): Promise<void> {
             core.info(
               `This build is using the new Oracle GraalVM. To select a specific distribution, use the 'distribution' option (see https://github.com/graalvm/setup-graalvm/tree/main#options).`
             )
-            graalVMHome = await graalvm.setUpGraalVMJDK(javaVersion, gdsToken)
+            graalVMHome = await graalvm.setUpGraalVMJDKByJavaVersion(javaVersion, gdsToken)
           }
           break
         default:
@@ -88,7 +100,7 @@ async function run(): Promise<void> {
             core.info(
               `This build is using the new Oracle GraalVM. To select a specific distribution, use the 'distribution' option (see https://github.com/graalvm/setup-graalvm/tree/main#options).`
             )
-            graalVMHome = await graalvm.setUpGraalVMJDK(javaVersion, gdsToken)
+            graalVMHome = await graalvm.setUpGraalVMJDKByJavaVersion(javaVersion, gdsToken)
           } else {
             graalVMHome = await graalvm.setUpGraalVMLatest_22_X(gdsToken, javaVersion)
           }
@@ -101,7 +113,7 @@ async function run(): Promise<void> {
             core.warning(
               `GraalVM dev builds are only available for JDK 21. This build is now using a stable release of GraalVM for JDK ${javaVersion}.`
             )
-            graalVMHome = await graalvm.setUpGraalVMJDK(javaVersion, gdsToken)
+            graalVMHome = await graalvm.setUpGraalVMJDKByJavaVersion(javaVersion, gdsToken)
           } else {
             graalVMHome = await graalvm.setUpGraalVMJDKDevBuild()
           }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -61,6 +61,17 @@ export async function getContents(repo: string, path: string): Promise<c.Content
   ).data
 }
 
+export async function getLastReleases(owner: string, repo: string): Promise<c.ListReleasesResponseData> {
+  const octokit = getOctokit()
+  return (
+    await octokit.request('GET /repos/{owner}/{repo}/releases', {
+      owner,
+      repo,
+      per_page: 100
+    })
+  ).data
+}
+
 export async function getTaggedRelease(owner: string, repo: string, tag: string): Promise<c.LatestReleaseResponseData> {
   const octokit = getOctokit()
   return (
@@ -69,7 +80,7 @@ export async function getTaggedRelease(owner: string, repo: string, tag: string)
       repo,
       tag
     })
-  ).data as c.LatestReleaseResponseData /** missing digest property */
+  ).data
 }
 
 export async function getMatchingTags(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -61,15 +61,13 @@ export async function getContents(repo: string, path: string): Promise<c.Content
   ).data
 }
 
-export async function getLastReleases(owner: string, repo: string): Promise<c.ListReleasesResponseData> {
+export async function getLastTags(owner: string, repo: string) {
   const octokit = getOctokit()
-  return (
-    await octokit.request('GET /repos/{owner}/{repo}/releases', {
-      owner,
-      repo,
-      per_page: 100
-    })
-  ).data
+  return octokit.paginate('GET /repos/{owner}/{repo}/tags', {
+    owner,
+    repo,
+    per_page: 100
+  })
 }
 
 export async function getTaggedRelease(owner: string, repo: string, tag: string): Promise<c.LatestReleaseResponseData> {


### PR DESCRIPTION
This PR adds support for GraalVM innovation releases. It also marks the `java-version` option as optional.

See `README.md` and `ci.yml` for how to download the new innovation releases with the `setup-graalvm` action.