### PR TITLE
Improve Visual Studio detection on Windows

### DIFF
--- a/dist/cleanup.js
+++ b/dist/cleanup.js
@@ -2784,24 +2784,15 @@ function requireDispatcherBase () {
 	const kOnDestroyed = Symbol('onDestroyed');
 	const kOnClosed = Symbol('onClosed');
 	const kInterceptedDispatch = Symbol('Intercepted Dispatch');
-	const kWebSocketOptions = Symbol('webSocketOptions');
 
 	class DispatcherBase extends Dispatcher {
-	  constructor (opts) {
+	  constructor () {
 	    super();
 
 	    this[kDestroyed] = false;
 	    this[kOnDestroyed] = null;
 	    this[kClosed] = false;
 	    this[kOnClosed] = [];
-	    this[kWebSocketOptions] = opts?.webSocket ?? {};
-	  }
-
-	  get webSocketOptions () {
-	    return {
-	      maxFragments: this[kWebSocketOptions].maxFragments ?? 131072,
-	      maxPayloadSize: this[kWebSocketOptions].maxPayloadSize ?? 128 * 1024 * 1024
-	    }
 	  }
 
 	  get destroyed () {
@@ -8751,9 +8742,6 @@ function requireClientH1 () {
 	const FastBuffer = Buffer[Symbol.species];
 	const addListener = util.addListener;
 	const removeAllListeners = util.removeAllListeners;
-	const kIdleSocketValidation = Symbol('kIdleSocketValidation');
-	const kIdleSocketValidationTimeout = Symbol('kIdleSocketValidationTimeout');
-	const kSocketUsed = Symbol('kSocketUsed');
 
 	let extractBody;
 
@@ -8976,69 +8964,27 @@ function requireClientH1 () {
 
 	      const offset = llhttp.llhttp_get_error_pos(this.ptr) - currentBufferPtr;
 
-	      if (ret !== constants.ERROR.OK) {
-	        const body = data.subarray(offset);
-
-	        if (ret === constants.ERROR.PAUSED_UPGRADE) {
-	          this.onUpgrade(body);
-	        } else if (ret === constants.ERROR.PAUSED) {
-	          this.paused = true;
-	          socket.unshift(body);
-	        } else {
-	          throw this.createError(ret, body)
+	      if (ret === constants.ERROR.PAUSED_UPGRADE) {
+	        this.onUpgrade(data.slice(offset));
+	      } else if (ret === constants.ERROR.PAUSED) {
+	        this.paused = true;
+	        socket.unshift(data.slice(offset));
+	      } else if (ret !== constants.ERROR.OK) {
+	        const ptr = llhttp.llhttp_get_error_reason(this.ptr);
+	        let message = '';
+	        /* istanbul ignore else: difficult to make a test case for */
+	        if (ptr) {
+	          const len = new Uint8Array(llhttp.memory.buffer, ptr).indexOf(0);
+	          message =
+	            'Response does not match the HTTP/1.1 protocol (' +
+	            Buffer.from(llhttp.memory.buffer, ptr, len).toString() +
+	            ')';
 	        }
+	        throw new HTTPParserError(message, constants.ERROR[ret], data.slice(offset))
 	      }
 	    } catch (err) {
 	      util.destroy(socket, err);
 	    }
-	  }
-
-	  finish () {
-	    assert(currentParser === null);
-	    assert(this.ptr != null);
-	    assert(!this.paused);
-
-	    const { llhttp } = this;
-
-	    let ret;
-
-	    try {
-	      currentParser = this;
-	      ret = llhttp.llhttp_finish(this.ptr);
-	    } finally {
-	      currentParser = null;
-	    }
-
-	    if (ret === constants.ERROR.OK) {
-	      return null
-	    }
-
-	    if (ret === constants.ERROR.PAUSED || ret === constants.ERROR.PAUSED_UPGRADE) {
-	      this.paused = true;
-	      return null
-	    }
-
-	    return this.createError(ret, EMPTY_BUF)
-	  }
-
-	  createError (ret, data) {
-	    const { llhttp, contentLength, bytesRead } = this;
-
-	    if (contentLength && bytesRead !== parseInt(contentLength, 10)) {
-	      return new ResponseContentLengthMismatchError()
-	    }
-
-	    const ptr = llhttp.llhttp_get_error_reason(this.ptr);
-	    let message = '';
-	    if (ptr) {
-	      const len = new Uint8Array(llhttp.memory.buffer, ptr).indexOf(0);
-	      message =
-	        'Response does not match the HTTP/1.1 protocol (' +
-	        Buffer.from(llhttp.memory.buffer, ptr, len).toString() +
-	        ')';
-	    }
-
-	    return new HTTPParserError(message, constants.ERROR[ret], data)
 	  }
 
 	  destroy () {
@@ -9065,11 +9011,6 @@ function requireClientH1 () {
 
 	    /* istanbul ignore next: difficult to make a test case for */
 	    if (socket.destroyed) {
-	      return -1
-	    }
-
-	    if (client[kRunning] === 0) {
-	      util.destroy(socket, new SocketError('bad response', util.getSocketInfo(socket)));
 	      return -1
 	    }
 
@@ -9173,11 +9114,6 @@ function requireClientH1 () {
 
 	    /* istanbul ignore next: difficult to make a test case for */
 	    if (socket.destroyed) {
-	      return -1
-	    }
-
-	    if (client[kRunning] === 0) {
-	      util.destroy(socket, new SocketError('bad response', util.getSocketInfo(socket)));
 	      return -1
 	    }
 
@@ -9354,7 +9290,6 @@ function requireClientH1 () {
 	    request.onComplete(headers);
 
 	    client[kQueue][client[kRunningIdx]++] = null;
-	    socket[kSocketUsed] = true;
 
 	    if (socket[kWriting]) {
 	      assert(client[kRunning] === 0);
@@ -9413,9 +9348,6 @@ function requireClientH1 () {
 	  socket[kWriting] = false;
 	  socket[kReset] = false;
 	  socket[kBlocking] = false;
-	  socket[kIdleSocketValidation] = 0;
-	  socket[kIdleSocketValidationTimeout] = null;
-	  socket[kSocketUsed] = false;
 	  socket[kParser] = new Parser(client, socket, llhttpInstance);
 
 	  addListener(socket, 'error', function (err) {
@@ -9426,11 +9358,8 @@ function requireClientH1 () {
 	    // On Mac OS, we get an ECONNRESET even if there is a full body to be forwarded
 	    // to the user.
 	    if (err.code === 'ECONNRESET' && parser.statusCode && !parser.shouldKeepAlive) {
-	      const parserErr = parser.finish();
-	      if (parserErr) {
-	        this[kError] = parserErr;
-	        this[kClient][kOnError](parserErr);
-	      }
+	      // We treat all incoming data so for as a valid response.
+	      parser.onMessageComplete();
 	      return
 	    }
 
@@ -9449,10 +9378,8 @@ function requireClientH1 () {
 	    const parser = this[kParser];
 
 	    if (parser.statusCode && !parser.shouldKeepAlive) {
-	      const parserErr = parser.finish();
-	      if (parserErr) {
-	        util.destroy(this, parserErr);
-	      }
+	      // We treat all incoming data so far as a valid response.
+	      parser.onMessageComplete();
 	      return
 	    }
 
@@ -9462,11 +9389,10 @@ function requireClientH1 () {
 	    const client = this[kClient];
 	    const parser = this[kParser];
 
-	    clearIdleSocketValidation(this);
-
 	    if (parser) {
 	      if (!this[kError] && parser.statusCode && !parser.shouldKeepAlive) {
-	        this[kError] = parser.finish() || this[kError];
+	        // We treat all incoming data so far as a valid response.
+	        parser.onMessageComplete();
 	      }
 
 	      this[kParser].destroy();
@@ -9529,7 +9455,7 @@ function requireClientH1 () {
 	      return socket.destroyed
 	    },
 	    busy (request) {
-	      if (socket[kWriting] || socket[kReset] || socket[kBlocking] || socket[kIdleSocketValidation] === 1) {
+	      if (socket[kWriting] || socket[kReset] || socket[kBlocking]) {
 	        return true
 	      }
 
@@ -9567,31 +9493,6 @@ function requireClientH1 () {
 	  }
 	}
 
-	function clearIdleSocketValidation (socket) {
-	  if (socket[kIdleSocketValidationTimeout]) {
-	    clearTimeout(socket[kIdleSocketValidationTimeout]);
-	    socket[kIdleSocketValidationTimeout] = null;
-	  }
-
-	  socket[kIdleSocketValidation] = 0;
-	}
-
-	function scheduleIdleSocketValidation (client, socket) {
-	  socket[kIdleSocketValidation] = 1;
-	  socket[kIdleSocketValidationTimeout] = setTimeout(() => {
-	    socket[kIdleSocketValidationTimeout] = null;
-	    socket[kIdleSocketValidation] = 2;
-
-	    if (client[kSocket] === socket && !socket.destroyed) {
-	      client[kResume]();
-	    }
-	  }, 0);
-	  socket[kIdleSocketValidationTimeout].unref?.();
-	}
-
-	/**
-	 * @param {import('./client.js')} client
-	 */
 	function resumeH1 (client) {
 	  const socket = client[kSocket];
 
@@ -9604,32 +9505,6 @@ function requireClientH1 () {
 	    } else if (socket[kNoRef] && socket.ref) {
 	      socket.ref();
 	      socket[kNoRef] = false;
-	    }
-
-	    if (client[kRunning] === 0 && client[kPending] > 0 && socket[kSocketUsed]) {
-	      if (socket[kIdleSocketValidation] === 0) {
-	        scheduleIdleSocketValidation(client, socket);
-	        socket[kParser].readMore();
-	        if (socket.destroyed) {
-	          return
-	        }
-	        return
-	      }
-
-	      if (socket[kIdleSocketValidation] === 1) {
-	        socket[kParser].readMore();
-	        if (socket.destroyed) {
-	          return
-	        }
-	        return
-	      }
-	    }
-
-	    if (client[kRunning] === 0) {
-	      socket[kParser].readMore();
-	      if (socket.destroyed) {
-	        return
-	      }
 	    }
 
 	    if (client[kSize] === 0) {
@@ -9725,7 +9600,6 @@ function requireClientH1 () {
 	  }
 
 	  const socket = client[kSocket];
-	  clearIdleSocketValidation(socket);
 
 	  const abort = (err) => {
 	    if (request.aborted || request.completed) {
@@ -11296,10 +11170,9 @@ function requireClient () {
 	    autoSelectFamilyAttemptTimeout,
 	    // h2
 	    maxConcurrentStreams,
-	    allowH2,
-	    webSocket
+	    allowH2
 	  } = {}) {
-	    super({ webSocket });
+	    super();
 
 	    if (keepAlive !== undefined) {
 	      throw new InvalidArgumentError('unsupported keepAlive, use pipelining=0 instead')
@@ -12006,8 +11879,8 @@ function requirePoolBase () {
 	const kStats = Symbol('stats');
 
 	class PoolBase extends DispatcherBase {
-	  constructor (opts) {
-	    super(opts);
+	  constructor () {
+	    super();
 
 	    this[kQueue] = new FixedQueue();
 	    this[kClients] = [];
@@ -12226,6 +12099,8 @@ function requirePool () {
 	    allowH2,
 	    ...options
 	  } = {}) {
+	    super();
+
 	    if (connections != null && (!Number.isFinite(connections) || connections < 0)) {
 	      throw new InvalidArgumentError('invalid connections')
 	    }
@@ -12249,8 +12124,6 @@ function requirePool () {
 	        ...connect
 	      });
 	    }
-
-	    super(options);
 
 	    this[kInterceptors] = options.interceptors?.Pool && Array.isArray(options.interceptors.Pool)
 	      ? options.interceptors.Pool
@@ -12545,6 +12418,8 @@ function requireAgent () {
 
 	class Agent extends DispatcherBase {
 	  constructor ({ factory = defaultFactory, maxRedirections = 0, connect, ...options } = {}) {
+	    super();
+
 	    if (typeof factory !== 'function') {
 	      throw new InvalidArgumentError('factory must be a function.')
 	    }
@@ -12556,8 +12431,6 @@ function requireAgent () {
 	    if (!Number.isInteger(maxRedirections) || maxRedirections < 0) {
 	      throw new InvalidArgumentError('maxRedirections must be a positive number')
 	    }
-
-	    super(options);
 
 	    if (connect && typeof connect !== 'function') {
 	      connect = { ...connect };
@@ -24208,25 +24081,32 @@ function requireParse$1 () {
 	    // If the attribute-name case-insensitively matches the string
 	    // "SameSite", the user agent MUST process the cookie-av as follows:
 
-	    const attributeValueLowercase = attributeValue.toLowerCase();
+	    // 1. Let enforcement be "Default".
+	    let enforcement = 'Default';
 
-	    // 1. If cookie-av's attribute-value is a case-insensitive match for
-	    //    "None", append an attribute to the cookie-attribute-list with an
-	    //    attribute-name of "SameSite" and an attribute-value of "None".
-	    if (attributeValueLowercase === 'none') {
-	      cookieAttributeList.sameSite = 'None';
-	    } else if (attributeValueLowercase === 'strict') {
-	      // 2. If cookie-av's attribute-value is a case-insensitive match for
-	      //    "Strict", append an attribute to the cookie-attribute-list with
-	      //    an attribute-name of "SameSite" and an attribute-value of
-	      //    "Strict".
-	      cookieAttributeList.sameSite = 'Strict';
-	    } else if (attributeValueLowercase === 'lax') {
-	      // 3. If cookie-av's attribute-value is a case-insensitive match for
-	      //    "Lax", append an attribute to the cookie-attribute-list with an
-	      //    attribute-name of "SameSite" and an attribute-value of "Lax".
-	      cookieAttributeList.sameSite = 'Lax';
+	    const attributeValueLowercase = attributeValue.toLowerCase();
+	    // 2. If cookie-av's attribute-value is a case-insensitive match for
+	    //    "None", set enforcement to "None".
+	    if (attributeValueLowercase.includes('none')) {
+	      enforcement = 'None';
 	    }
+
+	    // 3. If cookie-av's attribute-value is a case-insensitive match for
+	    //    "Strict", set enforcement to "Strict".
+	    if (attributeValueLowercase.includes('strict')) {
+	      enforcement = 'Strict';
+	    }
+
+	    // 4. If cookie-av's attribute-value is a case-insensitive match for
+	    //    "Lax", set enforcement to "Lax".
+	    if (attributeValueLowercase.includes('lax')) {
+	      enforcement = 'Lax';
+	    }
+
+	    // 5. Append an attribute to the cookie-attribute-list with an
+	    //    attribute-name of "SameSite" and an attribute-value of
+	    //    enforcement.
+	    cookieAttributeList.sameSite = enforcement;
 	  } else {
 	    cookieAttributeList.unparsed ??= [];
 
@@ -25692,35 +25572,40 @@ function requirePermessageDeflate () {
 	const kBuffer = Symbol('kBuffer');
 	const kLength = Symbol('kLength');
 
+	// Default maximum decompressed message size: 4 MB
+	const kDefaultMaxDecompressedSize = 4 * 1024 * 1024;
+
 	class PerMessageDeflate {
 	  /** @type {import('node:zlib').InflateRaw} */
 	  #inflate
 
 	  #options = {}
 
-	  #maxPayloadSize = 0
+	  /** @type {boolean} */
+	  #aborted = false
+
+	  /** @type {Function|null} */
+	  #currentCallback = null
 
 	  /**
 	   * @param {Map<string, string>} extensions
 	   */
-	  constructor (extensions, options) {
+	  constructor (extensions) {
 	    this.#options.serverNoContextTakeover = extensions.has('server_no_context_takeover');
 	    this.#options.serverMaxWindowBits = extensions.get('server_max_window_bits');
-
-	    this.#maxPayloadSize = options.maxPayloadSize;
 	  }
 
-	  /**
-	   * Decompress a compressed payload.
-	   * @param {Buffer} chunk Compressed data
-	   * @param {boolean} fin Final fragment flag
-	   * @param {Function} callback Callback function
-	   */
 	  decompress (chunk, fin, callback) {
 	    // An endpoint uses the following algorithm to decompress a message.
 	    // 1.  Append 4 octets of 0x00 0x00 0xff 0xff to the tail end of the
 	    //     payload of the message.
 	    // 2.  Decompress the resulting data using DEFLATE.
+
+	    if (this.#aborted) {
+	      callback(new MessageSizeExceededError());
+	      return
+	    }
+
 	    if (!this.#inflate) {
 	      let windowBits = Z_DEFAULT_WINDOWBITS;
 
@@ -25743,12 +25628,23 @@ function requirePermessageDeflate () {
 	      this.#inflate[kLength] = 0;
 
 	      this.#inflate.on('data', (data) => {
+	        if (this.#aborted) {
+	          return
+	        }
+
 	        this.#inflate[kLength] += data.length;
 
-	        if (this.#maxPayloadSize > 0 && this.#inflate[kLength] > this.#maxPayloadSize) {
-	          callback(new MessageSizeExceededError());
+	        if (this.#inflate[kLength] > kDefaultMaxDecompressedSize) {
+	          this.#aborted = true;
 	          this.#inflate.removeAllListeners();
+	          this.#inflate.destroy();
 	          this.#inflate = null;
+
+	          if (this.#currentCallback) {
+	            const cb = this.#currentCallback;
+	            this.#currentCallback = null;
+	            cb(new MessageSizeExceededError());
+	          }
 	          return
 	        }
 
@@ -25761,13 +25657,14 @@ function requirePermessageDeflate () {
 	      });
 	    }
 
+	    this.#currentCallback = callback;
 	    this.#inflate.write(chunk);
 	    if (fin) {
 	      this.#inflate.write(tail);
 	    }
 
 	    this.#inflate.flush(() => {
-	      if (!this.#inflate) {
+	      if (this.#aborted || !this.#inflate) {
 	        return
 	      }
 
@@ -25775,6 +25672,7 @@ function requirePermessageDeflate () {
 
 	      this.#inflate[kBuffer].length = 0;
 	      this.#inflate[kLength] = 0;
+	      this.#currentCallback = null;
 
 	      callback(null, full);
 	    });
@@ -25810,12 +25708,6 @@ function requireReceiver () {
 	const { WebsocketFrameSend } = requireFrame();
 	const { closeWebSocketConnection } = requireConnection();
 	const { PerMessageDeflate } = requirePermessageDeflate();
-	const { MessageSizeExceededError } = requireErrors();
-
-	function failWebsocketConnectionWithCode (ws, code, reason) {
-	  closeWebSocketConnection(ws, code, reason, Buffer.byteLength(reason));
-	  failWebsocketConnection(ws, reason);
-	}
 
 	// This code was influenced by ws released under the MIT license.
 	// Copyright (c) 2011 Einar Otto Stangvik <einaros@gmail.com>
@@ -25824,7 +25716,6 @@ function requireReceiver () {
 
 	class ByteParser extends Writable {
 	  #buffers = []
-	  #fragmentsBytes = 0
 	  #byteOffset = 0
 	  #loop = false
 
@@ -25836,27 +25727,18 @@ function requireReceiver () {
 	  /** @type {Map<string, PerMessageDeflate>} */
 	  #extensions
 
-	  /** @type {number} */
-	  #maxFragments
-
-	  /** @type {number} */
-	  #maxPayloadSize
-
 	  /**
 	   * @param {import('./websocket').WebSocket} ws
 	   * @param {Map<string, string>|null} extensions
-	   * @param {{ maxFragments?: number, maxPayloadSize?: number }} [options]
 	   */
-	  constructor (ws, extensions, options = {}) {
+	  constructor (ws, extensions) {
 	    super();
 
 	    this.ws = ws;
 	    this.#extensions = extensions == null ? new Map() : extensions;
-	    this.#maxFragments = options.maxFragments ?? 0;
-	    this.#maxPayloadSize = options.maxPayloadSize ?? 0;
 
 	    if (this.#extensions.has('permessage-deflate')) {
-	      this.#extensions.set('permessage-deflate', new PerMessageDeflate(extensions, options));
+	      this.#extensions.set('permessage-deflate', new PerMessageDeflate(extensions));
 	    }
 	  }
 
@@ -25870,19 +25752,6 @@ function requireReceiver () {
 	    this.#loop = true;
 
 	    this.run(callback);
-	  }
-
-	  #validatePayloadLength () {
-	    if (
-	      this.#maxPayloadSize > 0 &&
-	      !isControlFrame(this.#info.opcode) &&
-	      this.#info.payloadLength + this.#fragmentsBytes > this.#maxPayloadSize
-	    ) {
-	      failWebsocketConnectionWithCode(this.ws, 1009, 'Payload size exceeds maximum allowed size');
-	      return false
-	    }
-
-	    return true
 	  }
 
 	  /**
@@ -25973,10 +25842,6 @@ function requireReceiver () {
 	        if (payloadLength <= 125) {
 	          this.#info.payloadLength = payloadLength;
 	          this.#state = parserStates.READ_DATA;
-
-	          if (!this.#validatePayloadLength()) {
-	            return
-	          }
 	        } else if (payloadLength === 126) {
 	          this.#state = parserStates.PAYLOADLENGTH_16;
 	        } else if (payloadLength === 127) {
@@ -26001,10 +25866,6 @@ function requireReceiver () {
 
 	        this.#info.payloadLength = buffer.readUInt16BE(0);
 	        this.#state = parserStates.READ_DATA;
-
-	        if (!this.#validatePayloadLength()) {
-	          return
-	        }
 	      } else if (this.#state === parserStates.PAYLOADLENGTH_64) {
 	        if (this.#byteOffset < 8) {
 	          return callback()
@@ -26027,10 +25888,6 @@ function requireReceiver () {
 
 	        this.#info.payloadLength = lower;
 	        this.#state = parserStates.READ_DATA;
-
-	        if (!this.#validatePayloadLength()) {
-	          return
-	        }
 	      } else if (this.#state === parserStates.READ_DATA) {
 	        if (this.#byteOffset < this.#info.payloadLength) {
 	          return callback()
@@ -26043,58 +25900,42 @@ function requireReceiver () {
 	          this.#state = parserStates.INFO;
 	        } else {
 	          if (!this.#info.compressed) {
-	            if (!this.writeFragments(body)) {
-	              return
-	            }
-
-	            if (this.#maxPayloadSize > 0 && this.#fragmentsBytes > this.#maxPayloadSize) {
-	              failWebsocketConnectionWithCode(this.ws, 1009, new MessageSizeExceededError().message);
-	              return
-	            }
+	            this.#fragments.push(body);
 
 	            // If the frame is not fragmented, a message has been received.
 	            // If the frame is fragmented, it will terminate with a fin bit set
 	            // and an opcode of 0 (continuation), therefore we handle that when
 	            // parsing continuation frames, not here.
 	            if (!this.#info.fragmented && this.#info.fin) {
-	              websocketMessageReceived(this.ws, this.#info.binaryType, this.consumeFragments());
+	              const fullMessage = Buffer.concat(this.#fragments);
+	              websocketMessageReceived(this.ws, this.#info.binaryType, fullMessage);
+	              this.#fragments.length = 0;
 	            }
 
 	            this.#state = parserStates.INFO;
 	          } else {
-	            this.#extensions.get('permessage-deflate').decompress(
-	              body,
-	              this.#info.fin,
-	              (error, data) => {
-	                if (error) {
-	                  const code = error instanceof MessageSizeExceededError ? 1009 : 1007;
-	                  failWebsocketConnectionWithCode(this.ws, code, error.message);
-	                  return
-	                }
-
-	                if (!this.writeFragments(data)) {
-	                  return
-	                }
-
-	                if (this.#maxPayloadSize > 0 && this.#fragmentsBytes > this.#maxPayloadSize) {
-	                  failWebsocketConnectionWithCode(this.ws, 1009, new MessageSizeExceededError().message);
-	                  return
-	                }
-
-	                if (!this.#info.fin) {
-	                  this.#state = parserStates.INFO;
-	                  this.#loop = true;
-	                  this.run(callback);
-	                  return
-	                }
-
-	                websocketMessageReceived(this.ws, this.#info.binaryType, this.consumeFragments());
-
-	                this.#loop = true;
-	                this.#state = parserStates.INFO;
-	                this.run(callback);
+	            this.#extensions.get('permessage-deflate').decompress(body, this.#info.fin, (error, data) => {
+	              if (error) {
+	                failWebsocketConnection(this.ws, error.message);
+	                return
 	              }
-	            );
+
+	              this.#fragments.push(data);
+
+	              if (!this.#info.fin) {
+	                this.#state = parserStates.INFO;
+	                this.#loop = true;
+	                this.run(callback);
+	                return
+	              }
+
+	              websocketMessageReceived(this.ws, this.#info.binaryType, Buffer.concat(this.#fragments));
+
+	              this.#loop = true;
+	              this.#state = parserStates.INFO;
+	              this.#fragments.length = 0;
+	              this.run(callback);
+	            });
 
 	            this.#loop = false;
 	            break
@@ -26144,35 +25985,6 @@ function requireReceiver () {
 	    this.#byteOffset -= n;
 
 	    return buffer
-	  }
-
-	  writeFragments (fragment) {
-	    if (
-	      this.#maxFragments > 0 &&
-	      this.#fragments.length === this.#maxFragments
-	    ) {
-	      failWebsocketConnectionWithCode(this.ws, 1008, 'Too many message fragments');
-	      return false
-	    }
-
-	    this.#fragmentsBytes += fragment.length;
-	    this.#fragments.push(fragment);
-	    return true
-	  }
-
-	  consumeFragments () {
-	    const fragments = this.#fragments;
-
-	    if (fragments.length === 1) {
-	      this.#fragmentsBytes = 0;
-	      return fragments.shift()
-	    }
-
-	    const output = Buffer.concat(fragments, this.#fragmentsBytes);
-	    this.#fragments = [];
-	    this.#fragmentsBytes = 0;
-
-	    return output
 	  }
 
 	  parseCloseBody (data) {
@@ -26860,14 +26672,7 @@ function requireWebsocket () {
 	    // once this happens, the connection is open
 	    this[kResponse] = response;
 
-	    const webSocketOptions = this[kController]?.dispatcher?.webSocketOptions;
-	    const maxFragments = webSocketOptions?.maxFragments;
-	    const maxPayloadSize = webSocketOptions?.maxPayloadSize;
-
-	    const parser = new ByteParser(this, parsedExtensions, {
-	      maxFragments,
-	      maxPayloadSize
-	    });
+	    const parser = new ByteParser(this, parsedExtensions);
 	    parser.on('drain', onParserDrain);
 	    parser.on('error', onParserError.bind(this));
 
@@ -32856,22 +32661,6 @@ function requireSemver$1 () {
 
 	const parseOptions = requireParseOptions();
 	const { compareIdentifiers } = requireIdentifiers();
-
-	const isPrereleaseIdentifier = (prerelease, identifier) => {
-	  const identifiers = identifier.split('.');
-	  if (identifiers.length > prerelease.length) {
-	    return false
-	  }
-
-	  for (let i = 0; i < identifiers.length; i++) {
-	    if (compareIdentifiers(prerelease[i], identifiers[i]) !== 0) {
-	      return false
-	    }
-	  }
-
-	  return true
-	};
-
 	class SemVer {
 	  constructor (version, options) {
 	    options = parseOptions(options);
@@ -33175,9 +32964,8 @@ function requireSemver$1 () {
 	          if (identifierBase === false) {
 	            prerelease = [identifier];
 	          }
-	          if (isPrereleaseIdentifier(this.prerelease, identifier)) {
-	            const prereleaseBase = this.prerelease[identifier.split('.').length];
-	            if (isNaN(prereleaseBase)) {
+	          if (compareIdentifiers(this.prerelease[0], identifier) === 0) {
+	            if (isNaN(this.prerelease[1])) {
 	              this.prerelease = prerelease;
 	            }
 	          } else {
@@ -34095,11 +33883,6 @@ function requireRange () {
 
 	const isX = id => !id || id.toLowerCase() === 'x' || id === '*';
 
-	const invalidXRangeOrder = (M, m, p) => (
-	  (isX(M) && !isX(m)) ||
-	  (isX(m) && p && !isX(p))
-	);
-
 	// ~, ~> --> * (any, kinda silly)
 	// ~2, ~2.x, ~2.x.x, ~>2, ~>2.x ~>2.x.x --> >=2.0.0 <3.0.0-0
 	// ~2.0, ~2.0.x, ~>2.0, ~>2.0.x --> >=2.0.0 <2.1.0-0
@@ -34117,10 +33900,6 @@ function requireRange () {
 
 	const replaceTilde = (comp, options) => {
 	  const r = options.loose ? re[t.TILDELOOSE] : re[t.TILDE];
-	  // if we're including prereleases in the match, then the lower bound is
-	  // -0, the lowest possible prerelease value, just like x-ranges and carets.
-	  // this keeps `~1.2` equivalent to the `1.2.x` x-range it's documented as.
-	  const z = options.includePrerelease ? '-0' : '';
 	  return comp.replace(r, (_, M, m, p, pr) => {
 	    debug('tilde', comp, _, M, m, p, pr);
 	    let ret;
@@ -34128,10 +33907,10 @@ function requireRange () {
 	    if (isX(M)) {
 	      ret = '';
 	    } else if (isX(m)) {
-	      ret = `>=${M}.0.0${z} <${+M + 1}.0.0-0`;
+	      ret = `>=${M}.0.0 <${+M + 1}.0.0-0`;
 	    } else if (isX(p)) {
 	      // ~1.2 == >=1.2.0 <1.3.0-0
-	      ret = `>=${M}.${m}.0${z} <${M}.${+m + 1}.0-0`;
+	      ret = `>=${M}.${m}.0 <${M}.${+m + 1}.0-0`;
 	    } else if (pr) {
 	      debug('replaceTilde pr', pr);
 	      ret = `>=${M}.${m}.${p}-${pr
@@ -34200,10 +33979,10 @@ function requireRange () {
 	      if (M === '0') {
 	        if (m === '0') {
 	          ret = `>=${M}.${m}.${p
-	          } <${M}.${m}.${+p + 1}-0`;
+	          }${z} <${M}.${m}.${+p + 1}-0`;
 	        } else {
 	          ret = `>=${M}.${m}.${p
-	          } <${M}.${+m + 1}.0-0`;
+	          }${z} <${M}.${+m + 1}.0-0`;
 	        }
 	      } else {
 	        ret = `>=${M}.${m}.${p
@@ -34229,10 +34008,6 @@ function requireRange () {
 	  const r = options.loose ? re[t.XRANGELOOSE] : re[t.XRANGE];
 	  return comp.replace(r, (ret, gtlt, M, m, p, pr) => {
 	    debug('xRange', comp, ret, gtlt, M, m, p, pr);
-	    if (invalidXRangeOrder(M, m, p)) {
-	      return comp
-	    }
-
 	    const xM = isX(M);
 	    const xm = xM || isX(m);
 	    const xp = xm || isX(p);
@@ -72411,7 +72186,7 @@ function getCacheServiceURL() {
     }
 }
 
-var version = "6.1.0";
+var version = "6.0.1";
 var require$$0 = {
 	version: version};
 
@@ -76583,35 +76358,6 @@ class ReserveCacheError extends Error {
         Object.setPrototypeOf(this, ReserveCacheError.prototype);
     }
 }
-/**
- * Stable prefix the receiver writes into the cache reservation response when
- * the issuer downgraded the cache token to read-only (for example, because
- * the run was triggered by an untrusted event). saveCacheV1 / saveCacheV2
- * dispatch on this prefix to re-classify the failure as a
- * CacheWriteDeniedError so consumers (and the outer catch arm) can
- * distinguish a policy denial from other reservation failures.
- */
-const CACHE_WRITE_DENIED_PREFIX = 'cache write denied:';
-/**
- * Raised when the cache backend refuses to reserve a writable cache entry
- * because the JWT issued for this run was scoped read-only (for example, the
- * run was triggered by an event the repository administrator classified as
- * untrusted). The receiver-supplied detail message always begins with
- * `cache write denied:` (the full error message includes additional context
- * like the cache key).
- *
- * Extends ReserveCacheError for source-compatibility: existing
- * `instanceof ReserveCacheError` checks and `typedError.name ===
- * ReserveCacheError.name` paths keep working, while consumers that want to
- * distinguish the policy case can match on this subclass.
- */
-class CacheWriteDeniedError extends ReserveCacheError {
-    constructor(message) {
-        super(message);
-        this.name = 'CacheWriteDeniedError';
-        Object.setPrototypeOf(this, CacheWriteDeniedError.prototype);
-    }
-}
 class FinalizeCacheError extends Error {
     constructor(message) {
         super(message);
@@ -76668,7 +76414,7 @@ function saveCache$1(paths_1, key_1, options_1) {
  */
 function saveCacheV1(paths_1, key_1, options_1) {
     return __awaiter$3(this, arguments, void 0, function* (paths, key, options, enableCrossOsArchive = false) {
-        var _a, _b, _c, _d, _e, _f;
+        var _a, _b, _c, _d, _e;
         const compressionMethod = yield getCompressionMethod();
         let cacheId = -1;
         const cachePaths = yield resolvePaths(paths);
@@ -76705,17 +76451,7 @@ function saveCacheV1(paths_1, key_1, options_1) {
                 throw new Error((_d = (_c = reserveCacheResponse === null || reserveCacheResponse === void 0 ? void 0 : reserveCacheResponse.error) === null || _c === void 0 ? void 0 : _c.message) !== null && _d !== void 0 ? _d : `Cache size of ~${Math.round(archiveFileSize / (1024 * 1024))} MB (${archiveFileSize} B) is over the data cap limit, not saving cache.`);
             }
             else {
-                // Inspect the receiver's error message before deciding which error to
-                // throw. A message starting with the stable `cache write denied:`
-                // prefix indicates the issuer downgraded the token to read-only
-                // (policy denial), not a contention case, so we surface it as a
-                // CacheWriteDeniedError which the outer catch arm logs at warning
-                // level.
-                const detailMessage = (_e = reserveCacheResponse === null || reserveCacheResponse === void 0 ? void 0 : reserveCacheResponse.error) === null || _e === void 0 ? void 0 : _e.message;
-                if (detailMessage === null || detailMessage === void 0 ? void 0 : detailMessage.startsWith(CACHE_WRITE_DENIED_PREFIX)) {
-                    throw new CacheWriteDeniedError(`Unable to reserve cache with key ${key}. More details: ${detailMessage}`);
-                }
-                throw new ReserveCacheError(`Unable to reserve cache with key ${key}, another job may be creating this cache. More details: ${(_f = reserveCacheResponse === null || reserveCacheResponse === void 0 ? void 0 : reserveCacheResponse.error) === null || _f === void 0 ? void 0 : _f.message}`);
+                throw new ReserveCacheError(`Unable to reserve cache with key ${key}, another job may be creating this cache. More details: ${(_e = reserveCacheResponse === null || reserveCacheResponse === void 0 ? void 0 : reserveCacheResponse.error) === null || _e === void 0 ? void 0 : _e.message}`);
             }
             debug(`Saving Cache (ID: ${cacheId})`);
             yield saveCache$2(cacheId, archivePath, '', options);
@@ -76724,12 +76460,6 @@ function saveCacheV1(paths_1, key_1, options_1) {
             const typedError = error$1;
             if (typedError.name === ValidationError.name) {
                 throw error$1;
-            }
-            else if (typedError.name === CacheWriteDeniedError.name) {
-                // Cache write was denied by policy (read-only token). Surface to the
-                // customer at warning level so it is visible in the workflow log
-                // without failing the run.
-                warning(`Failed to save: ${typedError.message}`);
             }
             else if (typedError.name === ReserveCacheError.name) {
                 info(`Failed to save: ${typedError.message}`);
@@ -76769,7 +76499,6 @@ function saveCacheV1(paths_1, key_1, options_1) {
  */
 function saveCacheV2(paths_1, key_1, options_1) {
     return __awaiter$3(this, arguments, void 0, function* (paths, key, options, enableCrossOsArchive = false) {
-        var _a;
         // Override UploadOptions to force the use of Azure
         // ...options goes first because we want to override the default values
         // set in UploadOptions with these specific figures
@@ -76805,11 +76534,7 @@ function saveCacheV2(paths_1, key_1, options_1) {
             try {
                 const response = yield twirpClient.CreateCacheEntry(request);
                 if (!response.ok) {
-                    // Skip the redundant inner warning when the receiver signalled a
-                    // policy denial: the outer catch arm below will log a single
-                    // customer-facing warning.
-                    if (response.message &&
-                        !response.message.startsWith(CACHE_WRITE_DENIED_PREFIX)) {
+                    if (response.message) {
                         warning(`Cache reservation failed: ${response.message}`);
                     }
                     throw new Error(response.message || 'Response was not ok');
@@ -76818,10 +76543,6 @@ function saveCacheV2(paths_1, key_1, options_1) {
             }
             catch (error) {
                 debug(`Failed to reserve cache: ${error}`);
-                const errorMessage = (_a = error === null || error === void 0 ? void 0 : error.message) !== null && _a !== void 0 ? _a : '';
-                if (errorMessage.startsWith(CACHE_WRITE_DENIED_PREFIX)) {
-                    throw new CacheWriteDeniedError(`Unable to reserve cache with key ${key}. More details: ${errorMessage}`);
-                }
                 throw new ReserveCacheError(`Unable to reserve cache with key ${key}, another job may be creating this cache.`);
             }
             debug(`Attempting to upload cache located at: ${archivePath}`);
@@ -76845,12 +76566,6 @@ function saveCacheV2(paths_1, key_1, options_1) {
             const typedError = error$1;
             if (typedError.name === ValidationError.name) {
                 throw error$1;
-            }
-            else if (typedError.name === CacheWriteDeniedError.name) {
-                // Cache write was denied by policy (read-only token). Surface to the
-                // customer at warning level so it is visible in the workflow log
-                // without failing the run.
-                warning(`Failed to save: ${typedError.message}`);
             }
             else if (typedError.name === ReserveCacheError.name) {
                 info(`Failed to save: ${typedError.message}`);

--- a/dist/cleanup.js
+++ b/dist/cleanup.js
@@ -2784,15 +2784,24 @@ function requireDispatcherBase () {
 	const kOnDestroyed = Symbol('onDestroyed');
 	const kOnClosed = Symbol('onClosed');
 	const kInterceptedDispatch = Symbol('Intercepted Dispatch');
+	const kWebSocketOptions = Symbol('webSocketOptions');
 
 	class DispatcherBase extends Dispatcher {
-	  constructor () {
+	  constructor (opts) {
 	    super();
 
 	    this[kDestroyed] = false;
 	    this[kOnDestroyed] = null;
 	    this[kClosed] = false;
 	    this[kOnClosed] = [];
+	    this[kWebSocketOptions] = opts?.webSocket ?? {};
+	  }
+
+	  get webSocketOptions () {
+	    return {
+	      maxFragments: this[kWebSocketOptions].maxFragments ?? 131072,
+	      maxPayloadSize: this[kWebSocketOptions].maxPayloadSize ?? 128 * 1024 * 1024
+	    }
 	  }
 
 	  get destroyed () {
@@ -8742,6 +8751,9 @@ function requireClientH1 () {
 	const FastBuffer = Buffer[Symbol.species];
 	const addListener = util.addListener;
 	const removeAllListeners = util.removeAllListeners;
+	const kIdleSocketValidation = Symbol('kIdleSocketValidation');
+	const kIdleSocketValidationTimeout = Symbol('kIdleSocketValidationTimeout');
+	const kSocketUsed = Symbol('kSocketUsed');
 
 	let extractBody;
 
@@ -8964,27 +8976,69 @@ function requireClientH1 () {
 
 	      const offset = llhttp.llhttp_get_error_pos(this.ptr) - currentBufferPtr;
 
-	      if (ret === constants.ERROR.PAUSED_UPGRADE) {
-	        this.onUpgrade(data.slice(offset));
-	      } else if (ret === constants.ERROR.PAUSED) {
-	        this.paused = true;
-	        socket.unshift(data.slice(offset));
-	      } else if (ret !== constants.ERROR.OK) {
-	        const ptr = llhttp.llhttp_get_error_reason(this.ptr);
-	        let message = '';
-	        /* istanbul ignore else: difficult to make a test case for */
-	        if (ptr) {
-	          const len = new Uint8Array(llhttp.memory.buffer, ptr).indexOf(0);
-	          message =
-	            'Response does not match the HTTP/1.1 protocol (' +
-	            Buffer.from(llhttp.memory.buffer, ptr, len).toString() +
-	            ')';
+	      if (ret !== constants.ERROR.OK) {
+	        const body = data.subarray(offset);
+
+	        if (ret === constants.ERROR.PAUSED_UPGRADE) {
+	          this.onUpgrade(body);
+	        } else if (ret === constants.ERROR.PAUSED) {
+	          this.paused = true;
+	          socket.unshift(body);
+	        } else {
+	          throw this.createError(ret, body)
 	        }
-	        throw new HTTPParserError(message, constants.ERROR[ret], data.slice(offset))
 	      }
 	    } catch (err) {
 	      util.destroy(socket, err);
 	    }
+	  }
+
+	  finish () {
+	    assert(currentParser === null);
+	    assert(this.ptr != null);
+	    assert(!this.paused);
+
+	    const { llhttp } = this;
+
+	    let ret;
+
+	    try {
+	      currentParser = this;
+	      ret = llhttp.llhttp_finish(this.ptr);
+	    } finally {
+	      currentParser = null;
+	    }
+
+	    if (ret === constants.ERROR.OK) {
+	      return null
+	    }
+
+	    if (ret === constants.ERROR.PAUSED || ret === constants.ERROR.PAUSED_UPGRADE) {
+	      this.paused = true;
+	      return null
+	    }
+
+	    return this.createError(ret, EMPTY_BUF)
+	  }
+
+	  createError (ret, data) {
+	    const { llhttp, contentLength, bytesRead } = this;
+
+	    if (contentLength && bytesRead !== parseInt(contentLength, 10)) {
+	      return new ResponseContentLengthMismatchError()
+	    }
+
+	    const ptr = llhttp.llhttp_get_error_reason(this.ptr);
+	    let message = '';
+	    if (ptr) {
+	      const len = new Uint8Array(llhttp.memory.buffer, ptr).indexOf(0);
+	      message =
+	        'Response does not match the HTTP/1.1 protocol (' +
+	        Buffer.from(llhttp.memory.buffer, ptr, len).toString() +
+	        ')';
+	    }
+
+	    return new HTTPParserError(message, constants.ERROR[ret], data)
 	  }
 
 	  destroy () {
@@ -9011,6 +9065,11 @@ function requireClientH1 () {
 
 	    /* istanbul ignore next: difficult to make a test case for */
 	    if (socket.destroyed) {
+	      return -1
+	    }
+
+	    if (client[kRunning] === 0) {
+	      util.destroy(socket, new SocketError('bad response', util.getSocketInfo(socket)));
 	      return -1
 	    }
 
@@ -9114,6 +9173,11 @@ function requireClientH1 () {
 
 	    /* istanbul ignore next: difficult to make a test case for */
 	    if (socket.destroyed) {
+	      return -1
+	    }
+
+	    if (client[kRunning] === 0) {
+	      util.destroy(socket, new SocketError('bad response', util.getSocketInfo(socket)));
 	      return -1
 	    }
 
@@ -9290,6 +9354,7 @@ function requireClientH1 () {
 	    request.onComplete(headers);
 
 	    client[kQueue][client[kRunningIdx]++] = null;
+	    socket[kSocketUsed] = true;
 
 	    if (socket[kWriting]) {
 	      assert(client[kRunning] === 0);
@@ -9348,6 +9413,9 @@ function requireClientH1 () {
 	  socket[kWriting] = false;
 	  socket[kReset] = false;
 	  socket[kBlocking] = false;
+	  socket[kIdleSocketValidation] = 0;
+	  socket[kIdleSocketValidationTimeout] = null;
+	  socket[kSocketUsed] = false;
 	  socket[kParser] = new Parser(client, socket, llhttpInstance);
 
 	  addListener(socket, 'error', function (err) {
@@ -9358,8 +9426,11 @@ function requireClientH1 () {
 	    // On Mac OS, we get an ECONNRESET even if there is a full body to be forwarded
 	    // to the user.
 	    if (err.code === 'ECONNRESET' && parser.statusCode && !parser.shouldKeepAlive) {
-	      // We treat all incoming data so for as a valid response.
-	      parser.onMessageComplete();
+	      const parserErr = parser.finish();
+	      if (parserErr) {
+	        this[kError] = parserErr;
+	        this[kClient][kOnError](parserErr);
+	      }
 	      return
 	    }
 
@@ -9378,8 +9449,10 @@ function requireClientH1 () {
 	    const parser = this[kParser];
 
 	    if (parser.statusCode && !parser.shouldKeepAlive) {
-	      // We treat all incoming data so far as a valid response.
-	      parser.onMessageComplete();
+	      const parserErr = parser.finish();
+	      if (parserErr) {
+	        util.destroy(this, parserErr);
+	      }
 	      return
 	    }
 
@@ -9389,10 +9462,11 @@ function requireClientH1 () {
 	    const client = this[kClient];
 	    const parser = this[kParser];
 
+	    clearIdleSocketValidation(this);
+
 	    if (parser) {
 	      if (!this[kError] && parser.statusCode && !parser.shouldKeepAlive) {
-	        // We treat all incoming data so far as a valid response.
-	        parser.onMessageComplete();
+	        this[kError] = parser.finish() || this[kError];
 	      }
 
 	      this[kParser].destroy();
@@ -9455,7 +9529,7 @@ function requireClientH1 () {
 	      return socket.destroyed
 	    },
 	    busy (request) {
-	      if (socket[kWriting] || socket[kReset] || socket[kBlocking]) {
+	      if (socket[kWriting] || socket[kReset] || socket[kBlocking] || socket[kIdleSocketValidation] === 1) {
 	        return true
 	      }
 
@@ -9493,6 +9567,31 @@ function requireClientH1 () {
 	  }
 	}
 
+	function clearIdleSocketValidation (socket) {
+	  if (socket[kIdleSocketValidationTimeout]) {
+	    clearTimeout(socket[kIdleSocketValidationTimeout]);
+	    socket[kIdleSocketValidationTimeout] = null;
+	  }
+
+	  socket[kIdleSocketValidation] = 0;
+	}
+
+	function scheduleIdleSocketValidation (client, socket) {
+	  socket[kIdleSocketValidation] = 1;
+	  socket[kIdleSocketValidationTimeout] = setTimeout(() => {
+	    socket[kIdleSocketValidationTimeout] = null;
+	    socket[kIdleSocketValidation] = 2;
+
+	    if (client[kSocket] === socket && !socket.destroyed) {
+	      client[kResume]();
+	    }
+	  }, 0);
+	  socket[kIdleSocketValidationTimeout].unref?.();
+	}
+
+	/**
+	 * @param {import('./client.js')} client
+	 */
 	function resumeH1 (client) {
 	  const socket = client[kSocket];
 
@@ -9505,6 +9604,32 @@ function requireClientH1 () {
 	    } else if (socket[kNoRef] && socket.ref) {
 	      socket.ref();
 	      socket[kNoRef] = false;
+	    }
+
+	    if (client[kRunning] === 0 && client[kPending] > 0 && socket[kSocketUsed]) {
+	      if (socket[kIdleSocketValidation] === 0) {
+	        scheduleIdleSocketValidation(client, socket);
+	        socket[kParser].readMore();
+	        if (socket.destroyed) {
+	          return
+	        }
+	        return
+	      }
+
+	      if (socket[kIdleSocketValidation] === 1) {
+	        socket[kParser].readMore();
+	        if (socket.destroyed) {
+	          return
+	        }
+	        return
+	      }
+	    }
+
+	    if (client[kRunning] === 0) {
+	      socket[kParser].readMore();
+	      if (socket.destroyed) {
+	        return
+	      }
 	    }
 
 	    if (client[kSize] === 0) {
@@ -9600,6 +9725,7 @@ function requireClientH1 () {
 	  }
 
 	  const socket = client[kSocket];
+	  clearIdleSocketValidation(socket);
 
 	  const abort = (err) => {
 	    if (request.aborted || request.completed) {
@@ -11170,9 +11296,10 @@ function requireClient () {
 	    autoSelectFamilyAttemptTimeout,
 	    // h2
 	    maxConcurrentStreams,
-	    allowH2
+	    allowH2,
+	    webSocket
 	  } = {}) {
-	    super();
+	    super({ webSocket });
 
 	    if (keepAlive !== undefined) {
 	      throw new InvalidArgumentError('unsupported keepAlive, use pipelining=0 instead')
@@ -11879,8 +12006,8 @@ function requirePoolBase () {
 	const kStats = Symbol('stats');
 
 	class PoolBase extends DispatcherBase {
-	  constructor () {
-	    super();
+	  constructor (opts) {
+	    super(opts);
 
 	    this[kQueue] = new FixedQueue();
 	    this[kClients] = [];
@@ -12099,8 +12226,6 @@ function requirePool () {
 	    allowH2,
 	    ...options
 	  } = {}) {
-	    super();
-
 	    if (connections != null && (!Number.isFinite(connections) || connections < 0)) {
 	      throw new InvalidArgumentError('invalid connections')
 	    }
@@ -12124,6 +12249,8 @@ function requirePool () {
 	        ...connect
 	      });
 	    }
+
+	    super(options);
 
 	    this[kInterceptors] = options.interceptors?.Pool && Array.isArray(options.interceptors.Pool)
 	      ? options.interceptors.Pool
@@ -12418,8 +12545,6 @@ function requireAgent () {
 
 	class Agent extends DispatcherBase {
 	  constructor ({ factory = defaultFactory, maxRedirections = 0, connect, ...options } = {}) {
-	    super();
-
 	    if (typeof factory !== 'function') {
 	      throw new InvalidArgumentError('factory must be a function.')
 	    }
@@ -12431,6 +12556,8 @@ function requireAgent () {
 	    if (!Number.isInteger(maxRedirections) || maxRedirections < 0) {
 	      throw new InvalidArgumentError('maxRedirections must be a positive number')
 	    }
+
+	    super(options);
 
 	    if (connect && typeof connect !== 'function') {
 	      connect = { ...connect };
@@ -24081,32 +24208,25 @@ function requireParse$1 () {
 	    // If the attribute-name case-insensitively matches the string
 	    // "SameSite", the user agent MUST process the cookie-av as follows:
 
-	    // 1. Let enforcement be "Default".
-	    let enforcement = 'Default';
-
 	    const attributeValueLowercase = attributeValue.toLowerCase();
-	    // 2. If cookie-av's attribute-value is a case-insensitive match for
-	    //    "None", set enforcement to "None".
-	    if (attributeValueLowercase.includes('none')) {
-	      enforcement = 'None';
-	    }
 
-	    // 3. If cookie-av's attribute-value is a case-insensitive match for
-	    //    "Strict", set enforcement to "Strict".
-	    if (attributeValueLowercase.includes('strict')) {
-	      enforcement = 'Strict';
+	    // 1. If cookie-av's attribute-value is a case-insensitive match for
+	    //    "None", append an attribute to the cookie-attribute-list with an
+	    //    attribute-name of "SameSite" and an attribute-value of "None".
+	    if (attributeValueLowercase === 'none') {
+	      cookieAttributeList.sameSite = 'None';
+	    } else if (attributeValueLowercase === 'strict') {
+	      // 2. If cookie-av's attribute-value is a case-insensitive match for
+	      //    "Strict", append an attribute to the cookie-attribute-list with
+	      //    an attribute-name of "SameSite" and an attribute-value of
+	      //    "Strict".
+	      cookieAttributeList.sameSite = 'Strict';
+	    } else if (attributeValueLowercase === 'lax') {
+	      // 3. If cookie-av's attribute-value is a case-insensitive match for
+	      //    "Lax", append an attribute to the cookie-attribute-list with an
+	      //    attribute-name of "SameSite" and an attribute-value of "Lax".
+	      cookieAttributeList.sameSite = 'Lax';
 	    }
-
-	    // 4. If cookie-av's attribute-value is a case-insensitive match for
-	    //    "Lax", set enforcement to "Lax".
-	    if (attributeValueLowercase.includes('lax')) {
-	      enforcement = 'Lax';
-	    }
-
-	    // 5. Append an attribute to the cookie-attribute-list with an
-	    //    attribute-name of "SameSite" and an attribute-value of
-	    //    enforcement.
-	    cookieAttributeList.sameSite = enforcement;
 	  } else {
 	    cookieAttributeList.unparsed ??= [];
 
@@ -25572,40 +25692,35 @@ function requirePermessageDeflate () {
 	const kBuffer = Symbol('kBuffer');
 	const kLength = Symbol('kLength');
 
-	// Default maximum decompressed message size: 4 MB
-	const kDefaultMaxDecompressedSize = 4 * 1024 * 1024;
-
 	class PerMessageDeflate {
 	  /** @type {import('node:zlib').InflateRaw} */
 	  #inflate
 
 	  #options = {}
 
-	  /** @type {boolean} */
-	  #aborted = false
-
-	  /** @type {Function|null} */
-	  #currentCallback = null
+	  #maxPayloadSize = 0
 
 	  /**
 	   * @param {Map<string, string>} extensions
 	   */
-	  constructor (extensions) {
+	  constructor (extensions, options) {
 	    this.#options.serverNoContextTakeover = extensions.has('server_no_context_takeover');
 	    this.#options.serverMaxWindowBits = extensions.get('server_max_window_bits');
+
+	    this.#maxPayloadSize = options.maxPayloadSize;
 	  }
 
+	  /**
+	   * Decompress a compressed payload.
+	   * @param {Buffer} chunk Compressed data
+	   * @param {boolean} fin Final fragment flag
+	   * @param {Function} callback Callback function
+	   */
 	  decompress (chunk, fin, callback) {
 	    // An endpoint uses the following algorithm to decompress a message.
 	    // 1.  Append 4 octets of 0x00 0x00 0xff 0xff to the tail end of the
 	    //     payload of the message.
 	    // 2.  Decompress the resulting data using DEFLATE.
-
-	    if (this.#aborted) {
-	      callback(new MessageSizeExceededError());
-	      return
-	    }
-
 	    if (!this.#inflate) {
 	      let windowBits = Z_DEFAULT_WINDOWBITS;
 
@@ -25628,23 +25743,12 @@ function requirePermessageDeflate () {
 	      this.#inflate[kLength] = 0;
 
 	      this.#inflate.on('data', (data) => {
-	        if (this.#aborted) {
-	          return
-	        }
-
 	        this.#inflate[kLength] += data.length;
 
-	        if (this.#inflate[kLength] > kDefaultMaxDecompressedSize) {
-	          this.#aborted = true;
+	        if (this.#maxPayloadSize > 0 && this.#inflate[kLength] > this.#maxPayloadSize) {
+	          callback(new MessageSizeExceededError());
 	          this.#inflate.removeAllListeners();
-	          this.#inflate.destroy();
 	          this.#inflate = null;
-
-	          if (this.#currentCallback) {
-	            const cb = this.#currentCallback;
-	            this.#currentCallback = null;
-	            cb(new MessageSizeExceededError());
-	          }
 	          return
 	        }
 
@@ -25657,14 +25761,13 @@ function requirePermessageDeflate () {
 	      });
 	    }
 
-	    this.#currentCallback = callback;
 	    this.#inflate.write(chunk);
 	    if (fin) {
 	      this.#inflate.write(tail);
 	    }
 
 	    this.#inflate.flush(() => {
-	      if (this.#aborted || !this.#inflate) {
+	      if (!this.#inflate) {
 	        return
 	      }
 
@@ -25672,7 +25775,6 @@ function requirePermessageDeflate () {
 
 	      this.#inflate[kBuffer].length = 0;
 	      this.#inflate[kLength] = 0;
-	      this.#currentCallback = null;
 
 	      callback(null, full);
 	    });
@@ -25708,6 +25810,12 @@ function requireReceiver () {
 	const { WebsocketFrameSend } = requireFrame();
 	const { closeWebSocketConnection } = requireConnection();
 	const { PerMessageDeflate } = requirePermessageDeflate();
+	const { MessageSizeExceededError } = requireErrors();
+
+	function failWebsocketConnectionWithCode (ws, code, reason) {
+	  closeWebSocketConnection(ws, code, reason, Buffer.byteLength(reason));
+	  failWebsocketConnection(ws, reason);
+	}
 
 	// This code was influenced by ws released under the MIT license.
 	// Copyright (c) 2011 Einar Otto Stangvik <einaros@gmail.com>
@@ -25716,6 +25824,7 @@ function requireReceiver () {
 
 	class ByteParser extends Writable {
 	  #buffers = []
+	  #fragmentsBytes = 0
 	  #byteOffset = 0
 	  #loop = false
 
@@ -25727,18 +25836,27 @@ function requireReceiver () {
 	  /** @type {Map<string, PerMessageDeflate>} */
 	  #extensions
 
+	  /** @type {number} */
+	  #maxFragments
+
+	  /** @type {number} */
+	  #maxPayloadSize
+
 	  /**
 	   * @param {import('./websocket').WebSocket} ws
 	   * @param {Map<string, string>|null} extensions
+	   * @param {{ maxFragments?: number, maxPayloadSize?: number }} [options]
 	   */
-	  constructor (ws, extensions) {
+	  constructor (ws, extensions, options = {}) {
 	    super();
 
 	    this.ws = ws;
 	    this.#extensions = extensions == null ? new Map() : extensions;
+	    this.#maxFragments = options.maxFragments ?? 0;
+	    this.#maxPayloadSize = options.maxPayloadSize ?? 0;
 
 	    if (this.#extensions.has('permessage-deflate')) {
-	      this.#extensions.set('permessage-deflate', new PerMessageDeflate(extensions));
+	      this.#extensions.set('permessage-deflate', new PerMessageDeflate(extensions, options));
 	    }
 	  }
 
@@ -25752,6 +25870,19 @@ function requireReceiver () {
 	    this.#loop = true;
 
 	    this.run(callback);
+	  }
+
+	  #validatePayloadLength () {
+	    if (
+	      this.#maxPayloadSize > 0 &&
+	      !isControlFrame(this.#info.opcode) &&
+	      this.#info.payloadLength + this.#fragmentsBytes > this.#maxPayloadSize
+	    ) {
+	      failWebsocketConnectionWithCode(this.ws, 1009, 'Payload size exceeds maximum allowed size');
+	      return false
+	    }
+
+	    return true
 	  }
 
 	  /**
@@ -25842,6 +25973,10 @@ function requireReceiver () {
 	        if (payloadLength <= 125) {
 	          this.#info.payloadLength = payloadLength;
 	          this.#state = parserStates.READ_DATA;
+
+	          if (!this.#validatePayloadLength()) {
+	            return
+	          }
 	        } else if (payloadLength === 126) {
 	          this.#state = parserStates.PAYLOADLENGTH_16;
 	        } else if (payloadLength === 127) {
@@ -25866,6 +26001,10 @@ function requireReceiver () {
 
 	        this.#info.payloadLength = buffer.readUInt16BE(0);
 	        this.#state = parserStates.READ_DATA;
+
+	        if (!this.#validatePayloadLength()) {
+	          return
+	        }
 	      } else if (this.#state === parserStates.PAYLOADLENGTH_64) {
 	        if (this.#byteOffset < 8) {
 	          return callback()
@@ -25888,6 +26027,10 @@ function requireReceiver () {
 
 	        this.#info.payloadLength = lower;
 	        this.#state = parserStates.READ_DATA;
+
+	        if (!this.#validatePayloadLength()) {
+	          return
+	        }
 	      } else if (this.#state === parserStates.READ_DATA) {
 	        if (this.#byteOffset < this.#info.payloadLength) {
 	          return callback()
@@ -25900,42 +26043,58 @@ function requireReceiver () {
 	          this.#state = parserStates.INFO;
 	        } else {
 	          if (!this.#info.compressed) {
-	            this.#fragments.push(body);
+	            if (!this.writeFragments(body)) {
+	              return
+	            }
+
+	            if (this.#maxPayloadSize > 0 && this.#fragmentsBytes > this.#maxPayloadSize) {
+	              failWebsocketConnectionWithCode(this.ws, 1009, new MessageSizeExceededError().message);
+	              return
+	            }
 
 	            // If the frame is not fragmented, a message has been received.
 	            // If the frame is fragmented, it will terminate with a fin bit set
 	            // and an opcode of 0 (continuation), therefore we handle that when
 	            // parsing continuation frames, not here.
 	            if (!this.#info.fragmented && this.#info.fin) {
-	              const fullMessage = Buffer.concat(this.#fragments);
-	              websocketMessageReceived(this.ws, this.#info.binaryType, fullMessage);
-	              this.#fragments.length = 0;
+	              websocketMessageReceived(this.ws, this.#info.binaryType, this.consumeFragments());
 	            }
 
 	            this.#state = parserStates.INFO;
 	          } else {
-	            this.#extensions.get('permessage-deflate').decompress(body, this.#info.fin, (error, data) => {
-	              if (error) {
-	                failWebsocketConnection(this.ws, error.message);
-	                return
-	              }
+	            this.#extensions.get('permessage-deflate').decompress(
+	              body,
+	              this.#info.fin,
+	              (error, data) => {
+	                if (error) {
+	                  const code = error instanceof MessageSizeExceededError ? 1009 : 1007;
+	                  failWebsocketConnectionWithCode(this.ws, code, error.message);
+	                  return
+	                }
 
-	              this.#fragments.push(data);
+	                if (!this.writeFragments(data)) {
+	                  return
+	                }
 
-	              if (!this.#info.fin) {
-	                this.#state = parserStates.INFO;
+	                if (this.#maxPayloadSize > 0 && this.#fragmentsBytes > this.#maxPayloadSize) {
+	                  failWebsocketConnectionWithCode(this.ws, 1009, new MessageSizeExceededError().message);
+	                  return
+	                }
+
+	                if (!this.#info.fin) {
+	                  this.#state = parserStates.INFO;
+	                  this.#loop = true;
+	                  this.run(callback);
+	                  return
+	                }
+
+	                websocketMessageReceived(this.ws, this.#info.binaryType, this.consumeFragments());
+
 	                this.#loop = true;
+	                this.#state = parserStates.INFO;
 	                this.run(callback);
-	                return
 	              }
-
-	              websocketMessageReceived(this.ws, this.#info.binaryType, Buffer.concat(this.#fragments));
-
-	              this.#loop = true;
-	              this.#state = parserStates.INFO;
-	              this.#fragments.length = 0;
-	              this.run(callback);
-	            });
+	            );
 
 	            this.#loop = false;
 	            break
@@ -25985,6 +26144,35 @@ function requireReceiver () {
 	    this.#byteOffset -= n;
 
 	    return buffer
+	  }
+
+	  writeFragments (fragment) {
+	    if (
+	      this.#maxFragments > 0 &&
+	      this.#fragments.length === this.#maxFragments
+	    ) {
+	      failWebsocketConnectionWithCode(this.ws, 1008, 'Too many message fragments');
+	      return false
+	    }
+
+	    this.#fragmentsBytes += fragment.length;
+	    this.#fragments.push(fragment);
+	    return true
+	  }
+
+	  consumeFragments () {
+	    const fragments = this.#fragments;
+
+	    if (fragments.length === 1) {
+	      this.#fragmentsBytes = 0;
+	      return fragments.shift()
+	    }
+
+	    const output = Buffer.concat(fragments, this.#fragmentsBytes);
+	    this.#fragments = [];
+	    this.#fragmentsBytes = 0;
+
+	    return output
 	  }
 
 	  parseCloseBody (data) {
@@ -26672,7 +26860,14 @@ function requireWebsocket () {
 	    // once this happens, the connection is open
 	    this[kResponse] = response;
 
-	    const parser = new ByteParser(this, parsedExtensions);
+	    const webSocketOptions = this[kController]?.dispatcher?.webSocketOptions;
+	    const maxFragments = webSocketOptions?.maxFragments;
+	    const maxPayloadSize = webSocketOptions?.maxPayloadSize;
+
+	    const parser = new ByteParser(this, parsedExtensions, {
+	      maxFragments,
+	      maxPayloadSize
+	    });
 	    parser.on('drain', onParserDrain);
 	    parser.on('error', onParserError.bind(this));
 
@@ -32661,6 +32856,22 @@ function requireSemver$1 () {
 
 	const parseOptions = requireParseOptions();
 	const { compareIdentifiers } = requireIdentifiers();
+
+	const isPrereleaseIdentifier = (prerelease, identifier) => {
+	  const identifiers = identifier.split('.');
+	  if (identifiers.length > prerelease.length) {
+	    return false
+	  }
+
+	  for (let i = 0; i < identifiers.length; i++) {
+	    if (compareIdentifiers(prerelease[i], identifiers[i]) !== 0) {
+	      return false
+	    }
+	  }
+
+	  return true
+	};
+
 	class SemVer {
 	  constructor (version, options) {
 	    options = parseOptions(options);
@@ -32964,8 +33175,9 @@ function requireSemver$1 () {
 	          if (identifierBase === false) {
 	            prerelease = [identifier];
 	          }
-	          if (compareIdentifiers(this.prerelease[0], identifier) === 0) {
-	            if (isNaN(this.prerelease[1])) {
+	          if (isPrereleaseIdentifier(this.prerelease, identifier)) {
+	            const prereleaseBase = this.prerelease[identifier.split('.').length];
+	            if (isNaN(prereleaseBase)) {
 	              this.prerelease = prerelease;
 	            }
 	          } else {
@@ -33883,6 +34095,11 @@ function requireRange () {
 
 	const isX = id => !id || id.toLowerCase() === 'x' || id === '*';
 
+	const invalidXRangeOrder = (M, m, p) => (
+	  (isX(M) && !isX(m)) ||
+	  (isX(m) && p && !isX(p))
+	);
+
 	// ~, ~> --> * (any, kinda silly)
 	// ~2, ~2.x, ~2.x.x, ~>2, ~>2.x ~>2.x.x --> >=2.0.0 <3.0.0-0
 	// ~2.0, ~2.0.x, ~>2.0, ~>2.0.x --> >=2.0.0 <2.1.0-0
@@ -33900,6 +34117,10 @@ function requireRange () {
 
 	const replaceTilde = (comp, options) => {
 	  const r = options.loose ? re[t.TILDELOOSE] : re[t.TILDE];
+	  // if we're including prereleases in the match, then the lower bound is
+	  // -0, the lowest possible prerelease value, just like x-ranges and carets.
+	  // this keeps `~1.2` equivalent to the `1.2.x` x-range it's documented as.
+	  const z = options.includePrerelease ? '-0' : '';
 	  return comp.replace(r, (_, M, m, p, pr) => {
 	    debug('tilde', comp, _, M, m, p, pr);
 	    let ret;
@@ -33907,10 +34128,10 @@ function requireRange () {
 	    if (isX(M)) {
 	      ret = '';
 	    } else if (isX(m)) {
-	      ret = `>=${M}.0.0 <${+M + 1}.0.0-0`;
+	      ret = `>=${M}.0.0${z} <${+M + 1}.0.0-0`;
 	    } else if (isX(p)) {
 	      // ~1.2 == >=1.2.0 <1.3.0-0
-	      ret = `>=${M}.${m}.0 <${M}.${+m + 1}.0-0`;
+	      ret = `>=${M}.${m}.0${z} <${M}.${+m + 1}.0-0`;
 	    } else if (pr) {
 	      debug('replaceTilde pr', pr);
 	      ret = `>=${M}.${m}.${p}-${pr
@@ -33979,10 +34200,10 @@ function requireRange () {
 	      if (M === '0') {
 	        if (m === '0') {
 	          ret = `>=${M}.${m}.${p
-	          }${z} <${M}.${m}.${+p + 1}-0`;
+	          } <${M}.${m}.${+p + 1}-0`;
 	        } else {
 	          ret = `>=${M}.${m}.${p
-	          }${z} <${M}.${+m + 1}.0-0`;
+	          } <${M}.${+m + 1}.0-0`;
 	        }
 	      } else {
 	        ret = `>=${M}.${m}.${p
@@ -34008,6 +34229,10 @@ function requireRange () {
 	  const r = options.loose ? re[t.XRANGELOOSE] : re[t.XRANGE];
 	  return comp.replace(r, (ret, gtlt, M, m, p, pr) => {
 	    debug('xRange', comp, ret, gtlt, M, m, p, pr);
+	    if (invalidXRangeOrder(M, m, p)) {
+	      return comp
+	    }
+
 	    const xM = isX(M);
 	    const xm = xM || isX(m);
 	    const xp = xm || isX(p);
@@ -72186,7 +72411,7 @@ function getCacheServiceURL() {
     }
 }
 
-var version = "6.0.1";
+var version = "6.1.0";
 var require$$0 = {
 	version: version};
 
@@ -76358,6 +76583,35 @@ class ReserveCacheError extends Error {
         Object.setPrototypeOf(this, ReserveCacheError.prototype);
     }
 }
+/**
+ * Stable prefix the receiver writes into the cache reservation response when
+ * the issuer downgraded the cache token to read-only (for example, because
+ * the run was triggered by an untrusted event). saveCacheV1 / saveCacheV2
+ * dispatch on this prefix to re-classify the failure as a
+ * CacheWriteDeniedError so consumers (and the outer catch arm) can
+ * distinguish a policy denial from other reservation failures.
+ */
+const CACHE_WRITE_DENIED_PREFIX = 'cache write denied:';
+/**
+ * Raised when the cache backend refuses to reserve a writable cache entry
+ * because the JWT issued for this run was scoped read-only (for example, the
+ * run was triggered by an event the repository administrator classified as
+ * untrusted). The receiver-supplied detail message always begins with
+ * `cache write denied:` (the full error message includes additional context
+ * like the cache key).
+ *
+ * Extends ReserveCacheError for source-compatibility: existing
+ * `instanceof ReserveCacheError` checks and `typedError.name ===
+ * ReserveCacheError.name` paths keep working, while consumers that want to
+ * distinguish the policy case can match on this subclass.
+ */
+class CacheWriteDeniedError extends ReserveCacheError {
+    constructor(message) {
+        super(message);
+        this.name = 'CacheWriteDeniedError';
+        Object.setPrototypeOf(this, CacheWriteDeniedError.prototype);
+    }
+}
 class FinalizeCacheError extends Error {
     constructor(message) {
         super(message);
@@ -76414,7 +76668,7 @@ function saveCache$1(paths_1, key_1, options_1) {
  */
 function saveCacheV1(paths_1, key_1, options_1) {
     return __awaiter$3(this, arguments, void 0, function* (paths, key, options, enableCrossOsArchive = false) {
-        var _a, _b, _c, _d, _e;
+        var _a, _b, _c, _d, _e, _f;
         const compressionMethod = yield getCompressionMethod();
         let cacheId = -1;
         const cachePaths = yield resolvePaths(paths);
@@ -76451,7 +76705,17 @@ function saveCacheV1(paths_1, key_1, options_1) {
                 throw new Error((_d = (_c = reserveCacheResponse === null || reserveCacheResponse === void 0 ? void 0 : reserveCacheResponse.error) === null || _c === void 0 ? void 0 : _c.message) !== null && _d !== void 0 ? _d : `Cache size of ~${Math.round(archiveFileSize / (1024 * 1024))} MB (${archiveFileSize} B) is over the data cap limit, not saving cache.`);
             }
             else {
-                throw new ReserveCacheError(`Unable to reserve cache with key ${key}, another job may be creating this cache. More details: ${(_e = reserveCacheResponse === null || reserveCacheResponse === void 0 ? void 0 : reserveCacheResponse.error) === null || _e === void 0 ? void 0 : _e.message}`);
+                // Inspect the receiver's error message before deciding which error to
+                // throw. A message starting with the stable `cache write denied:`
+                // prefix indicates the issuer downgraded the token to read-only
+                // (policy denial), not a contention case, so we surface it as a
+                // CacheWriteDeniedError which the outer catch arm logs at warning
+                // level.
+                const detailMessage = (_e = reserveCacheResponse === null || reserveCacheResponse === void 0 ? void 0 : reserveCacheResponse.error) === null || _e === void 0 ? void 0 : _e.message;
+                if (detailMessage === null || detailMessage === void 0 ? void 0 : detailMessage.startsWith(CACHE_WRITE_DENIED_PREFIX)) {
+                    throw new CacheWriteDeniedError(`Unable to reserve cache with key ${key}. More details: ${detailMessage}`);
+                }
+                throw new ReserveCacheError(`Unable to reserve cache with key ${key}, another job may be creating this cache. More details: ${(_f = reserveCacheResponse === null || reserveCacheResponse === void 0 ? void 0 : reserveCacheResponse.error) === null || _f === void 0 ? void 0 : _f.message}`);
             }
             debug(`Saving Cache (ID: ${cacheId})`);
             yield saveCache$2(cacheId, archivePath, '', options);
@@ -76460,6 +76724,12 @@ function saveCacheV1(paths_1, key_1, options_1) {
             const typedError = error$1;
             if (typedError.name === ValidationError.name) {
                 throw error$1;
+            }
+            else if (typedError.name === CacheWriteDeniedError.name) {
+                // Cache write was denied by policy (read-only token). Surface to the
+                // customer at warning level so it is visible in the workflow log
+                // without failing the run.
+                warning(`Failed to save: ${typedError.message}`);
             }
             else if (typedError.name === ReserveCacheError.name) {
                 info(`Failed to save: ${typedError.message}`);
@@ -76499,6 +76769,7 @@ function saveCacheV1(paths_1, key_1, options_1) {
  */
 function saveCacheV2(paths_1, key_1, options_1) {
     return __awaiter$3(this, arguments, void 0, function* (paths, key, options, enableCrossOsArchive = false) {
+        var _a;
         // Override UploadOptions to force the use of Azure
         // ...options goes first because we want to override the default values
         // set in UploadOptions with these specific figures
@@ -76534,7 +76805,11 @@ function saveCacheV2(paths_1, key_1, options_1) {
             try {
                 const response = yield twirpClient.CreateCacheEntry(request);
                 if (!response.ok) {
-                    if (response.message) {
+                    // Skip the redundant inner warning when the receiver signalled a
+                    // policy denial: the outer catch arm below will log a single
+                    // customer-facing warning.
+                    if (response.message &&
+                        !response.message.startsWith(CACHE_WRITE_DENIED_PREFIX)) {
                         warning(`Cache reservation failed: ${response.message}`);
                     }
                     throw new Error(response.message || 'Response was not ok');
@@ -76543,6 +76818,10 @@ function saveCacheV2(paths_1, key_1, options_1) {
             }
             catch (error) {
                 debug(`Failed to reserve cache: ${error}`);
+                const errorMessage = (_a = error === null || error === void 0 ? void 0 : error.message) !== null && _a !== void 0 ? _a : '';
+                if (errorMessage.startsWith(CACHE_WRITE_DENIED_PREFIX)) {
+                    throw new CacheWriteDeniedError(`Unable to reserve cache with key ${key}. More details: ${errorMessage}`);
+                }
                 throw new ReserveCacheError(`Unable to reserve cache with key ${key}, another job may be creating this cache.`);
             }
             debug(`Attempting to upload cache located at: ${archivePath}`);
@@ -76566,6 +76845,12 @@ function saveCacheV2(paths_1, key_1, options_1) {
             const typedError = error$1;
             if (typedError.name === ValidationError.name) {
                 throw error$1;
+            }
+            else if (typedError.name === CacheWriteDeniedError.name) {
+                // Cache write was denied by policy (read-only token). Surface to the
+                // customer at warning level so it is visible in the workflow log
+                // without failing the run.
+                warning(`Failed to save: ${typedError.message}`);
             }
             else if (typedError.name === ReserveCacheError.name) {
                 info(`Failed to save: ${typedError.message}`);

--- a/dist/main.js
+++ b/dist/main.js
@@ -2902,15 +2902,24 @@ function requireDispatcherBase () {
 	const kOnDestroyed = Symbol('onDestroyed');
 	const kOnClosed = Symbol('onClosed');
 	const kInterceptedDispatch = Symbol('Intercepted Dispatch');
+	const kWebSocketOptions = Symbol('webSocketOptions');
 
 	class DispatcherBase extends Dispatcher {
-	  constructor () {
+	  constructor (opts) {
 	    super();
 
 	    this[kDestroyed] = false;
 	    this[kOnDestroyed] = null;
 	    this[kClosed] = false;
 	    this[kOnClosed] = [];
+	    this[kWebSocketOptions] = opts?.webSocket ?? {};
+	  }
+
+	  get webSocketOptions () {
+	    return {
+	      maxFragments: this[kWebSocketOptions].maxFragments ?? 131072,
+	      maxPayloadSize: this[kWebSocketOptions].maxPayloadSize ?? 128 * 1024 * 1024
+	    }
 	  }
 
 	  get destroyed () {
@@ -8860,6 +8869,9 @@ function requireClientH1 () {
 	const FastBuffer = Buffer[Symbol.species];
 	const addListener = util.addListener;
 	const removeAllListeners = util.removeAllListeners;
+	const kIdleSocketValidation = Symbol('kIdleSocketValidation');
+	const kIdleSocketValidationTimeout = Symbol('kIdleSocketValidationTimeout');
+	const kSocketUsed = Symbol('kSocketUsed');
 
 	let extractBody;
 
@@ -9082,27 +9094,69 @@ function requireClientH1 () {
 
 	      const offset = llhttp.llhttp_get_error_pos(this.ptr) - currentBufferPtr;
 
-	      if (ret === constants.ERROR.PAUSED_UPGRADE) {
-	        this.onUpgrade(data.slice(offset));
-	      } else if (ret === constants.ERROR.PAUSED) {
-	        this.paused = true;
-	        socket.unshift(data.slice(offset));
-	      } else if (ret !== constants.ERROR.OK) {
-	        const ptr = llhttp.llhttp_get_error_reason(this.ptr);
-	        let message = '';
-	        /* istanbul ignore else: difficult to make a test case for */
-	        if (ptr) {
-	          const len = new Uint8Array(llhttp.memory.buffer, ptr).indexOf(0);
-	          message =
-	            'Response does not match the HTTP/1.1 protocol (' +
-	            Buffer.from(llhttp.memory.buffer, ptr, len).toString() +
-	            ')';
+	      if (ret !== constants.ERROR.OK) {
+	        const body = data.subarray(offset);
+
+	        if (ret === constants.ERROR.PAUSED_UPGRADE) {
+	          this.onUpgrade(body);
+	        } else if (ret === constants.ERROR.PAUSED) {
+	          this.paused = true;
+	          socket.unshift(body);
+	        } else {
+	          throw this.createError(ret, body)
 	        }
-	        throw new HTTPParserError(message, constants.ERROR[ret], data.slice(offset))
 	      }
 	    } catch (err) {
 	      util.destroy(socket, err);
 	    }
+	  }
+
+	  finish () {
+	    assert(currentParser === null);
+	    assert(this.ptr != null);
+	    assert(!this.paused);
+
+	    const { llhttp } = this;
+
+	    let ret;
+
+	    try {
+	      currentParser = this;
+	      ret = llhttp.llhttp_finish(this.ptr);
+	    } finally {
+	      currentParser = null;
+	    }
+
+	    if (ret === constants.ERROR.OK) {
+	      return null
+	    }
+
+	    if (ret === constants.ERROR.PAUSED || ret === constants.ERROR.PAUSED_UPGRADE) {
+	      this.paused = true;
+	      return null
+	    }
+
+	    return this.createError(ret, EMPTY_BUF)
+	  }
+
+	  createError (ret, data) {
+	    const { llhttp, contentLength, bytesRead } = this;
+
+	    if (contentLength && bytesRead !== parseInt(contentLength, 10)) {
+	      return new ResponseContentLengthMismatchError()
+	    }
+
+	    const ptr = llhttp.llhttp_get_error_reason(this.ptr);
+	    let message = '';
+	    if (ptr) {
+	      const len = new Uint8Array(llhttp.memory.buffer, ptr).indexOf(0);
+	      message =
+	        'Response does not match the HTTP/1.1 protocol (' +
+	        Buffer.from(llhttp.memory.buffer, ptr, len).toString() +
+	        ')';
+	    }
+
+	    return new HTTPParserError(message, constants.ERROR[ret], data)
 	  }
 
 	  destroy () {
@@ -9129,6 +9183,11 @@ function requireClientH1 () {
 
 	    /* istanbul ignore next: difficult to make a test case for */
 	    if (socket.destroyed) {
+	      return -1
+	    }
+
+	    if (client[kRunning] === 0) {
+	      util.destroy(socket, new SocketError('bad response', util.getSocketInfo(socket)));
 	      return -1
 	    }
 
@@ -9232,6 +9291,11 @@ function requireClientH1 () {
 
 	    /* istanbul ignore next: difficult to make a test case for */
 	    if (socket.destroyed) {
+	      return -1
+	    }
+
+	    if (client[kRunning] === 0) {
+	      util.destroy(socket, new SocketError('bad response', util.getSocketInfo(socket)));
 	      return -1
 	    }
 
@@ -9408,6 +9472,7 @@ function requireClientH1 () {
 	    request.onComplete(headers);
 
 	    client[kQueue][client[kRunningIdx]++] = null;
+	    socket[kSocketUsed] = true;
 
 	    if (socket[kWriting]) {
 	      assert(client[kRunning] === 0);
@@ -9466,6 +9531,9 @@ function requireClientH1 () {
 	  socket[kWriting] = false;
 	  socket[kReset] = false;
 	  socket[kBlocking] = false;
+	  socket[kIdleSocketValidation] = 0;
+	  socket[kIdleSocketValidationTimeout] = null;
+	  socket[kSocketUsed] = false;
 	  socket[kParser] = new Parser(client, socket, llhttpInstance);
 
 	  addListener(socket, 'error', function (err) {
@@ -9476,8 +9544,11 @@ function requireClientH1 () {
 	    // On Mac OS, we get an ECONNRESET even if there is a full body to be forwarded
 	    // to the user.
 	    if (err.code === 'ECONNRESET' && parser.statusCode && !parser.shouldKeepAlive) {
-	      // We treat all incoming data so for as a valid response.
-	      parser.onMessageComplete();
+	      const parserErr = parser.finish();
+	      if (parserErr) {
+	        this[kError] = parserErr;
+	        this[kClient][kOnError](parserErr);
+	      }
 	      return
 	    }
 
@@ -9496,8 +9567,10 @@ function requireClientH1 () {
 	    const parser = this[kParser];
 
 	    if (parser.statusCode && !parser.shouldKeepAlive) {
-	      // We treat all incoming data so far as a valid response.
-	      parser.onMessageComplete();
+	      const parserErr = parser.finish();
+	      if (parserErr) {
+	        util.destroy(this, parserErr);
+	      }
 	      return
 	    }
 
@@ -9507,10 +9580,11 @@ function requireClientH1 () {
 	    const client = this[kClient];
 	    const parser = this[kParser];
 
+	    clearIdleSocketValidation(this);
+
 	    if (parser) {
 	      if (!this[kError] && parser.statusCode && !parser.shouldKeepAlive) {
-	        // We treat all incoming data so far as a valid response.
-	        parser.onMessageComplete();
+	        this[kError] = parser.finish() || this[kError];
 	      }
 
 	      this[kParser].destroy();
@@ -9573,7 +9647,7 @@ function requireClientH1 () {
 	      return socket.destroyed
 	    },
 	    busy (request) {
-	      if (socket[kWriting] || socket[kReset] || socket[kBlocking]) {
+	      if (socket[kWriting] || socket[kReset] || socket[kBlocking] || socket[kIdleSocketValidation] === 1) {
 	        return true
 	      }
 
@@ -9611,6 +9685,31 @@ function requireClientH1 () {
 	  }
 	}
 
+	function clearIdleSocketValidation (socket) {
+	  if (socket[kIdleSocketValidationTimeout]) {
+	    clearTimeout(socket[kIdleSocketValidationTimeout]);
+	    socket[kIdleSocketValidationTimeout] = null;
+	  }
+
+	  socket[kIdleSocketValidation] = 0;
+	}
+
+	function scheduleIdleSocketValidation (client, socket) {
+	  socket[kIdleSocketValidation] = 1;
+	  socket[kIdleSocketValidationTimeout] = setTimeout(() => {
+	    socket[kIdleSocketValidationTimeout] = null;
+	    socket[kIdleSocketValidation] = 2;
+
+	    if (client[kSocket] === socket && !socket.destroyed) {
+	      client[kResume]();
+	    }
+	  }, 0);
+	  socket[kIdleSocketValidationTimeout].unref?.();
+	}
+
+	/**
+	 * @param {import('./client.js')} client
+	 */
 	function resumeH1 (client) {
 	  const socket = client[kSocket];
 
@@ -9623,6 +9722,32 @@ function requireClientH1 () {
 	    } else if (socket[kNoRef] && socket.ref) {
 	      socket.ref();
 	      socket[kNoRef] = false;
+	    }
+
+	    if (client[kRunning] === 0 && client[kPending] > 0 && socket[kSocketUsed]) {
+	      if (socket[kIdleSocketValidation] === 0) {
+	        scheduleIdleSocketValidation(client, socket);
+	        socket[kParser].readMore();
+	        if (socket.destroyed) {
+	          return
+	        }
+	        return
+	      }
+
+	      if (socket[kIdleSocketValidation] === 1) {
+	        socket[kParser].readMore();
+	        if (socket.destroyed) {
+	          return
+	        }
+	        return
+	      }
+	    }
+
+	    if (client[kRunning] === 0) {
+	      socket[kParser].readMore();
+	      if (socket.destroyed) {
+	        return
+	      }
 	    }
 
 	    if (client[kSize] === 0) {
@@ -9718,6 +9843,7 @@ function requireClientH1 () {
 	  }
 
 	  const socket = client[kSocket];
+	  clearIdleSocketValidation(socket);
 
 	  const abort = (err) => {
 	    if (request.aborted || request.completed) {
@@ -11288,9 +11414,10 @@ function requireClient () {
 	    autoSelectFamilyAttemptTimeout,
 	    // h2
 	    maxConcurrentStreams,
-	    allowH2
+	    allowH2,
+	    webSocket
 	  } = {}) {
-	    super();
+	    super({ webSocket });
 
 	    if (keepAlive !== undefined) {
 	      throw new InvalidArgumentError('unsupported keepAlive, use pipelining=0 instead')
@@ -11997,8 +12124,8 @@ function requirePoolBase () {
 	const kStats = Symbol('stats');
 
 	class PoolBase extends DispatcherBase {
-	  constructor () {
-	    super();
+	  constructor (opts) {
+	    super(opts);
 
 	    this[kQueue] = new FixedQueue();
 	    this[kClients] = [];
@@ -12217,8 +12344,6 @@ function requirePool () {
 	    allowH2,
 	    ...options
 	  } = {}) {
-	    super();
-
 	    if (connections != null && (!Number.isFinite(connections) || connections < 0)) {
 	      throw new InvalidArgumentError('invalid connections')
 	    }
@@ -12242,6 +12367,8 @@ function requirePool () {
 	        ...connect
 	      });
 	    }
+
+	    super(options);
 
 	    this[kInterceptors] = options.interceptors?.Pool && Array.isArray(options.interceptors.Pool)
 	      ? options.interceptors.Pool
@@ -12536,8 +12663,6 @@ function requireAgent () {
 
 	class Agent extends DispatcherBase {
 	  constructor ({ factory = defaultFactory, maxRedirections = 0, connect, ...options } = {}) {
-	    super();
-
 	    if (typeof factory !== 'function') {
 	      throw new InvalidArgumentError('factory must be a function.')
 	    }
@@ -12549,6 +12674,8 @@ function requireAgent () {
 	    if (!Number.isInteger(maxRedirections) || maxRedirections < 0) {
 	      throw new InvalidArgumentError('maxRedirections must be a positive number')
 	    }
+
+	    super(options);
 
 	    if (connect && typeof connect !== 'function') {
 	      connect = { ...connect };
@@ -24199,32 +24326,25 @@ function requireParse$1 () {
 	    // If the attribute-name case-insensitively matches the string
 	    // "SameSite", the user agent MUST process the cookie-av as follows:
 
-	    // 1. Let enforcement be "Default".
-	    let enforcement = 'Default';
-
 	    const attributeValueLowercase = attributeValue.toLowerCase();
-	    // 2. If cookie-av's attribute-value is a case-insensitive match for
-	    //    "None", set enforcement to "None".
-	    if (attributeValueLowercase.includes('none')) {
-	      enforcement = 'None';
-	    }
 
-	    // 3. If cookie-av's attribute-value is a case-insensitive match for
-	    //    "Strict", set enforcement to "Strict".
-	    if (attributeValueLowercase.includes('strict')) {
-	      enforcement = 'Strict';
+	    // 1. If cookie-av's attribute-value is a case-insensitive match for
+	    //    "None", append an attribute to the cookie-attribute-list with an
+	    //    attribute-name of "SameSite" and an attribute-value of "None".
+	    if (attributeValueLowercase === 'none') {
+	      cookieAttributeList.sameSite = 'None';
+	    } else if (attributeValueLowercase === 'strict') {
+	      // 2. If cookie-av's attribute-value is a case-insensitive match for
+	      //    "Strict", append an attribute to the cookie-attribute-list with
+	      //    an attribute-name of "SameSite" and an attribute-value of
+	      //    "Strict".
+	      cookieAttributeList.sameSite = 'Strict';
+	    } else if (attributeValueLowercase === 'lax') {
+	      // 3. If cookie-av's attribute-value is a case-insensitive match for
+	      //    "Lax", append an attribute to the cookie-attribute-list with an
+	      //    attribute-name of "SameSite" and an attribute-value of "Lax".
+	      cookieAttributeList.sameSite = 'Lax';
 	    }
-
-	    // 4. If cookie-av's attribute-value is a case-insensitive match for
-	    //    "Lax", set enforcement to "Lax".
-	    if (attributeValueLowercase.includes('lax')) {
-	      enforcement = 'Lax';
-	    }
-
-	    // 5. Append an attribute to the cookie-attribute-list with an
-	    //    attribute-name of "SameSite" and an attribute-value of
-	    //    enforcement.
-	    cookieAttributeList.sameSite = enforcement;
 	  } else {
 	    cookieAttributeList.unparsed ??= [];
 
@@ -25690,40 +25810,35 @@ function requirePermessageDeflate () {
 	const kBuffer = Symbol('kBuffer');
 	const kLength = Symbol('kLength');
 
-	// Default maximum decompressed message size: 4 MB
-	const kDefaultMaxDecompressedSize = 4 * 1024 * 1024;
-
 	class PerMessageDeflate {
 	  /** @type {import('node:zlib').InflateRaw} */
 	  #inflate
 
 	  #options = {}
 
-	  /** @type {boolean} */
-	  #aborted = false
-
-	  /** @type {Function|null} */
-	  #currentCallback = null
+	  #maxPayloadSize = 0
 
 	  /**
 	   * @param {Map<string, string>} extensions
 	   */
-	  constructor (extensions) {
+	  constructor (extensions, options) {
 	    this.#options.serverNoContextTakeover = extensions.has('server_no_context_takeover');
 	    this.#options.serverMaxWindowBits = extensions.get('server_max_window_bits');
+
+	    this.#maxPayloadSize = options.maxPayloadSize;
 	  }
 
+	  /**
+	   * Decompress a compressed payload.
+	   * @param {Buffer} chunk Compressed data
+	   * @param {boolean} fin Final fragment flag
+	   * @param {Function} callback Callback function
+	   */
 	  decompress (chunk, fin, callback) {
 	    // An endpoint uses the following algorithm to decompress a message.
 	    // 1.  Append 4 octets of 0x00 0x00 0xff 0xff to the tail end of the
 	    //     payload of the message.
 	    // 2.  Decompress the resulting data using DEFLATE.
-
-	    if (this.#aborted) {
-	      callback(new MessageSizeExceededError());
-	      return
-	    }
-
 	    if (!this.#inflate) {
 	      let windowBits = Z_DEFAULT_WINDOWBITS;
 
@@ -25746,23 +25861,12 @@ function requirePermessageDeflate () {
 	      this.#inflate[kLength] = 0;
 
 	      this.#inflate.on('data', (data) => {
-	        if (this.#aborted) {
-	          return
-	        }
-
 	        this.#inflate[kLength] += data.length;
 
-	        if (this.#inflate[kLength] > kDefaultMaxDecompressedSize) {
-	          this.#aborted = true;
+	        if (this.#maxPayloadSize > 0 && this.#inflate[kLength] > this.#maxPayloadSize) {
+	          callback(new MessageSizeExceededError());
 	          this.#inflate.removeAllListeners();
-	          this.#inflate.destroy();
 	          this.#inflate = null;
-
-	          if (this.#currentCallback) {
-	            const cb = this.#currentCallback;
-	            this.#currentCallback = null;
-	            cb(new MessageSizeExceededError());
-	          }
 	          return
 	        }
 
@@ -25775,14 +25879,13 @@ function requirePermessageDeflate () {
 	      });
 	    }
 
-	    this.#currentCallback = callback;
 	    this.#inflate.write(chunk);
 	    if (fin) {
 	      this.#inflate.write(tail);
 	    }
 
 	    this.#inflate.flush(() => {
-	      if (this.#aborted || !this.#inflate) {
+	      if (!this.#inflate) {
 	        return
 	      }
 
@@ -25790,7 +25893,6 @@ function requirePermessageDeflate () {
 
 	      this.#inflate[kBuffer].length = 0;
 	      this.#inflate[kLength] = 0;
-	      this.#currentCallback = null;
 
 	      callback(null, full);
 	    });
@@ -25826,6 +25928,12 @@ function requireReceiver () {
 	const { WebsocketFrameSend } = requireFrame();
 	const { closeWebSocketConnection } = requireConnection();
 	const { PerMessageDeflate } = requirePermessageDeflate();
+	const { MessageSizeExceededError } = requireErrors();
+
+	function failWebsocketConnectionWithCode (ws, code, reason) {
+	  closeWebSocketConnection(ws, code, reason, Buffer.byteLength(reason));
+	  failWebsocketConnection(ws, reason);
+	}
 
 	// This code was influenced by ws released under the MIT license.
 	// Copyright (c) 2011 Einar Otto Stangvik <einaros@gmail.com>
@@ -25834,6 +25942,7 @@ function requireReceiver () {
 
 	class ByteParser extends Writable {
 	  #buffers = []
+	  #fragmentsBytes = 0
 	  #byteOffset = 0
 	  #loop = false
 
@@ -25845,18 +25954,27 @@ function requireReceiver () {
 	  /** @type {Map<string, PerMessageDeflate>} */
 	  #extensions
 
+	  /** @type {number} */
+	  #maxFragments
+
+	  /** @type {number} */
+	  #maxPayloadSize
+
 	  /**
 	   * @param {import('./websocket').WebSocket} ws
 	   * @param {Map<string, string>|null} extensions
+	   * @param {{ maxFragments?: number, maxPayloadSize?: number }} [options]
 	   */
-	  constructor (ws, extensions) {
+	  constructor (ws, extensions, options = {}) {
 	    super();
 
 	    this.ws = ws;
 	    this.#extensions = extensions == null ? new Map() : extensions;
+	    this.#maxFragments = options.maxFragments ?? 0;
+	    this.#maxPayloadSize = options.maxPayloadSize ?? 0;
 
 	    if (this.#extensions.has('permessage-deflate')) {
-	      this.#extensions.set('permessage-deflate', new PerMessageDeflate(extensions));
+	      this.#extensions.set('permessage-deflate', new PerMessageDeflate(extensions, options));
 	    }
 	  }
 
@@ -25870,6 +25988,19 @@ function requireReceiver () {
 	    this.#loop = true;
 
 	    this.run(callback);
+	  }
+
+	  #validatePayloadLength () {
+	    if (
+	      this.#maxPayloadSize > 0 &&
+	      !isControlFrame(this.#info.opcode) &&
+	      this.#info.payloadLength + this.#fragmentsBytes > this.#maxPayloadSize
+	    ) {
+	      failWebsocketConnectionWithCode(this.ws, 1009, 'Payload size exceeds maximum allowed size');
+	      return false
+	    }
+
+	    return true
 	  }
 
 	  /**
@@ -25960,6 +26091,10 @@ function requireReceiver () {
 	        if (payloadLength <= 125) {
 	          this.#info.payloadLength = payloadLength;
 	          this.#state = parserStates.READ_DATA;
+
+	          if (!this.#validatePayloadLength()) {
+	            return
+	          }
 	        } else if (payloadLength === 126) {
 	          this.#state = parserStates.PAYLOADLENGTH_16;
 	        } else if (payloadLength === 127) {
@@ -25984,6 +26119,10 @@ function requireReceiver () {
 
 	        this.#info.payloadLength = buffer.readUInt16BE(0);
 	        this.#state = parserStates.READ_DATA;
+
+	        if (!this.#validatePayloadLength()) {
+	          return
+	        }
 	      } else if (this.#state === parserStates.PAYLOADLENGTH_64) {
 	        if (this.#byteOffset < 8) {
 	          return callback()
@@ -26006,6 +26145,10 @@ function requireReceiver () {
 
 	        this.#info.payloadLength = lower;
 	        this.#state = parserStates.READ_DATA;
+
+	        if (!this.#validatePayloadLength()) {
+	          return
+	        }
 	      } else if (this.#state === parserStates.READ_DATA) {
 	        if (this.#byteOffset < this.#info.payloadLength) {
 	          return callback()
@@ -26018,42 +26161,58 @@ function requireReceiver () {
 	          this.#state = parserStates.INFO;
 	        } else {
 	          if (!this.#info.compressed) {
-	            this.#fragments.push(body);
+	            if (!this.writeFragments(body)) {
+	              return
+	            }
+
+	            if (this.#maxPayloadSize > 0 && this.#fragmentsBytes > this.#maxPayloadSize) {
+	              failWebsocketConnectionWithCode(this.ws, 1009, new MessageSizeExceededError().message);
+	              return
+	            }
 
 	            // If the frame is not fragmented, a message has been received.
 	            // If the frame is fragmented, it will terminate with a fin bit set
 	            // and an opcode of 0 (continuation), therefore we handle that when
 	            // parsing continuation frames, not here.
 	            if (!this.#info.fragmented && this.#info.fin) {
-	              const fullMessage = Buffer.concat(this.#fragments);
-	              websocketMessageReceived(this.ws, this.#info.binaryType, fullMessage);
-	              this.#fragments.length = 0;
+	              websocketMessageReceived(this.ws, this.#info.binaryType, this.consumeFragments());
 	            }
 
 	            this.#state = parserStates.INFO;
 	          } else {
-	            this.#extensions.get('permessage-deflate').decompress(body, this.#info.fin, (error, data) => {
-	              if (error) {
-	                failWebsocketConnection(this.ws, error.message);
-	                return
-	              }
+	            this.#extensions.get('permessage-deflate').decompress(
+	              body,
+	              this.#info.fin,
+	              (error, data) => {
+	                if (error) {
+	                  const code = error instanceof MessageSizeExceededError ? 1009 : 1007;
+	                  failWebsocketConnectionWithCode(this.ws, code, error.message);
+	                  return
+	                }
 
-	              this.#fragments.push(data);
+	                if (!this.writeFragments(data)) {
+	                  return
+	                }
 
-	              if (!this.#info.fin) {
-	                this.#state = parserStates.INFO;
+	                if (this.#maxPayloadSize > 0 && this.#fragmentsBytes > this.#maxPayloadSize) {
+	                  failWebsocketConnectionWithCode(this.ws, 1009, new MessageSizeExceededError().message);
+	                  return
+	                }
+
+	                if (!this.#info.fin) {
+	                  this.#state = parserStates.INFO;
+	                  this.#loop = true;
+	                  this.run(callback);
+	                  return
+	                }
+
+	                websocketMessageReceived(this.ws, this.#info.binaryType, this.consumeFragments());
+
 	                this.#loop = true;
+	                this.#state = parserStates.INFO;
 	                this.run(callback);
-	                return
 	              }
-
-	              websocketMessageReceived(this.ws, this.#info.binaryType, Buffer.concat(this.#fragments));
-
-	              this.#loop = true;
-	              this.#state = parserStates.INFO;
-	              this.#fragments.length = 0;
-	              this.run(callback);
-	            });
+	            );
 
 	            this.#loop = false;
 	            break
@@ -26103,6 +26262,35 @@ function requireReceiver () {
 	    this.#byteOffset -= n;
 
 	    return buffer
+	  }
+
+	  writeFragments (fragment) {
+	    if (
+	      this.#maxFragments > 0 &&
+	      this.#fragments.length === this.#maxFragments
+	    ) {
+	      failWebsocketConnectionWithCode(this.ws, 1008, 'Too many message fragments');
+	      return false
+	    }
+
+	    this.#fragmentsBytes += fragment.length;
+	    this.#fragments.push(fragment);
+	    return true
+	  }
+
+	  consumeFragments () {
+	    const fragments = this.#fragments;
+
+	    if (fragments.length === 1) {
+	      this.#fragmentsBytes = 0;
+	      return fragments.shift()
+	    }
+
+	    const output = Buffer.concat(fragments, this.#fragmentsBytes);
+	    this.#fragments = [];
+	    this.#fragmentsBytes = 0;
+
+	    return output
 	  }
 
 	  parseCloseBody (data) {
@@ -26790,7 +26978,14 @@ function requireWebsocket () {
 	    // once this happens, the connection is open
 	    this[kResponse] = response;
 
-	    const parser = new ByteParser(this, parsedExtensions);
+	    const webSocketOptions = this[kController]?.dispatcher?.webSocketOptions;
+	    const maxFragments = webSocketOptions?.maxFragments;
+	    const maxPayloadSize = webSocketOptions?.maxPayloadSize;
+
+	    const parser = new ByteParser(this, parsedExtensions, {
+	      maxFragments,
+	      maxPayloadSize
+	    });
 	    parser.on('drain', onParserDrain);
 	    parser.on('error', onParserError.bind(this));
 
@@ -30402,6 +30597,22 @@ function requireSemver$1 () {
 
 	const parseOptions = requireParseOptions();
 	const { compareIdentifiers } = requireIdentifiers();
+
+	const isPrereleaseIdentifier = (prerelease, identifier) => {
+	  const identifiers = identifier.split('.');
+	  if (identifiers.length > prerelease.length) {
+	    return false
+	  }
+
+	  for (let i = 0; i < identifiers.length; i++) {
+	    if (compareIdentifiers(prerelease[i], identifiers[i]) !== 0) {
+	      return false
+	    }
+	  }
+
+	  return true
+	};
+
 	class SemVer {
 	  constructor (version, options) {
 	    options = parseOptions(options);
@@ -30705,8 +30916,9 @@ function requireSemver$1 () {
 	          if (identifierBase === false) {
 	            prerelease = [identifier];
 	          }
-	          if (compareIdentifiers(this.prerelease[0], identifier) === 0) {
-	            if (isNaN(this.prerelease[1])) {
+	          if (isPrereleaseIdentifier(this.prerelease, identifier)) {
+	            const prereleaseBase = this.prerelease[identifier.split('.').length];
+	            if (isNaN(prereleaseBase)) {
 	              this.prerelease = prerelease;
 	            }
 	          } else {
@@ -31624,6 +31836,11 @@ function requireRange () {
 
 	const isX = id => !id || id.toLowerCase() === 'x' || id === '*';
 
+	const invalidXRangeOrder = (M, m, p) => (
+	  (isX(M) && !isX(m)) ||
+	  (isX(m) && p && !isX(p))
+	);
+
 	// ~, ~> --> * (any, kinda silly)
 	// ~2, ~2.x, ~2.x.x, ~>2, ~>2.x ~>2.x.x --> >=2.0.0 <3.0.0-0
 	// ~2.0, ~2.0.x, ~>2.0, ~>2.0.x --> >=2.0.0 <2.1.0-0
@@ -31641,6 +31858,10 @@ function requireRange () {
 
 	const replaceTilde = (comp, options) => {
 	  const r = options.loose ? re[t.TILDELOOSE] : re[t.TILDE];
+	  // if we're including prereleases in the match, then the lower bound is
+	  // -0, the lowest possible prerelease value, just like x-ranges and carets.
+	  // this keeps `~1.2` equivalent to the `1.2.x` x-range it's documented as.
+	  const z = options.includePrerelease ? '-0' : '';
 	  return comp.replace(r, (_, M, m, p, pr) => {
 	    debug('tilde', comp, _, M, m, p, pr);
 	    let ret;
@@ -31648,10 +31869,10 @@ function requireRange () {
 	    if (isX(M)) {
 	      ret = '';
 	    } else if (isX(m)) {
-	      ret = `>=${M}.0.0 <${+M + 1}.0.0-0`;
+	      ret = `>=${M}.0.0${z} <${+M + 1}.0.0-0`;
 	    } else if (isX(p)) {
 	      // ~1.2 == >=1.2.0 <1.3.0-0
-	      ret = `>=${M}.${m}.0 <${M}.${+m + 1}.0-0`;
+	      ret = `>=${M}.${m}.0${z} <${M}.${+m + 1}.0-0`;
 	    } else if (pr) {
 	      debug('replaceTilde pr', pr);
 	      ret = `>=${M}.${m}.${p}-${pr
@@ -31720,10 +31941,10 @@ function requireRange () {
 	      if (M === '0') {
 	        if (m === '0') {
 	          ret = `>=${M}.${m}.${p
-	          }${z} <${M}.${m}.${+p + 1}-0`;
+	          } <${M}.${m}.${+p + 1}-0`;
 	        } else {
 	          ret = `>=${M}.${m}.${p
-	          }${z} <${M}.${+m + 1}.0-0`;
+	          } <${M}.${+m + 1}.0-0`;
 	        }
 	      } else {
 	        ret = `>=${M}.${m}.${p
@@ -31749,6 +31970,10 @@ function requireRange () {
 	  const r = options.loose ? re[t.XRANGELOOSE] : re[t.XRANGE];
 	  return comp.replace(r, (ret, gtlt, M, m, p, pr) => {
 	    debug('xRange', comp, ret, gtlt, M, m, p, pr);
+	    if (invalidXRangeOrder(M, m, p)) {
+	      return comp
+	    }
+
 	    const xM = isX(M);
 	    const xm = xM || isX(m);
 	    const xp = xm || isX(p);
@@ -77790,7 +78015,7 @@ function getCacheServiceURL() {
     }
 }
 
-var version = "6.0.1";
+var version = "6.1.0";
 var require$$0 = {
 	version: version};
 
@@ -83606,7 +83831,17 @@ async function run() {
         const enableNativeImageMusl = getInput(INPUT_NI_MUSL) === 'true';
         const isGraalVMforJDK17OrLater = distribution.length > 0 || graalVMVersion.length == 0;
         if (IS_WINDOWS$9) {
-            setUpWindowsEnvironment();
+            try {
+                setUpWindowsEnvironment();
+            }
+            catch (error) {
+                if (isGraalVMforJDK17OrLater) {
+                    warning(`${error instanceof Error ? error.message : error}. Native Image on JDK 17+ can detect the Windows environment automatically.`);
+                }
+                else {
+                    throw error;
+                }
+            }
         }
         await setUpDependencies(components);
         if (enableNativeImageMusl) {

--- a/dist/main.js
+++ b/dist/main.js
@@ -2902,24 +2902,15 @@ function requireDispatcherBase () {
 	const kOnDestroyed = Symbol('onDestroyed');
 	const kOnClosed = Symbol('onClosed');
 	const kInterceptedDispatch = Symbol('Intercepted Dispatch');
-	const kWebSocketOptions = Symbol('webSocketOptions');
 
 	class DispatcherBase extends Dispatcher {
-	  constructor (opts) {
+	  constructor () {
 	    super();
 
 	    this[kDestroyed] = false;
 	    this[kOnDestroyed] = null;
 	    this[kClosed] = false;
 	    this[kOnClosed] = [];
-	    this[kWebSocketOptions] = opts?.webSocket ?? {};
-	  }
-
-	  get webSocketOptions () {
-	    return {
-	      maxFragments: this[kWebSocketOptions].maxFragments ?? 131072,
-	      maxPayloadSize: this[kWebSocketOptions].maxPayloadSize ?? 128 * 1024 * 1024
-	    }
 	  }
 
 	  get destroyed () {
@@ -8869,9 +8860,6 @@ function requireClientH1 () {
 	const FastBuffer = Buffer[Symbol.species];
 	const addListener = util.addListener;
 	const removeAllListeners = util.removeAllListeners;
-	const kIdleSocketValidation = Symbol('kIdleSocketValidation');
-	const kIdleSocketValidationTimeout = Symbol('kIdleSocketValidationTimeout');
-	const kSocketUsed = Symbol('kSocketUsed');
 
 	let extractBody;
 
@@ -9094,69 +9082,27 @@ function requireClientH1 () {
 
 	      const offset = llhttp.llhttp_get_error_pos(this.ptr) - currentBufferPtr;
 
-	      if (ret !== constants.ERROR.OK) {
-	        const body = data.subarray(offset);
-
-	        if (ret === constants.ERROR.PAUSED_UPGRADE) {
-	          this.onUpgrade(body);
-	        } else if (ret === constants.ERROR.PAUSED) {
-	          this.paused = true;
-	          socket.unshift(body);
-	        } else {
-	          throw this.createError(ret, body)
+	      if (ret === constants.ERROR.PAUSED_UPGRADE) {
+	        this.onUpgrade(data.slice(offset));
+	      } else if (ret === constants.ERROR.PAUSED) {
+	        this.paused = true;
+	        socket.unshift(data.slice(offset));
+	      } else if (ret !== constants.ERROR.OK) {
+	        const ptr = llhttp.llhttp_get_error_reason(this.ptr);
+	        let message = '';
+	        /* istanbul ignore else: difficult to make a test case for */
+	        if (ptr) {
+	          const len = new Uint8Array(llhttp.memory.buffer, ptr).indexOf(0);
+	          message =
+	            'Response does not match the HTTP/1.1 protocol (' +
+	            Buffer.from(llhttp.memory.buffer, ptr, len).toString() +
+	            ')';
 	        }
+	        throw new HTTPParserError(message, constants.ERROR[ret], data.slice(offset))
 	      }
 	    } catch (err) {
 	      util.destroy(socket, err);
 	    }
-	  }
-
-	  finish () {
-	    assert(currentParser === null);
-	    assert(this.ptr != null);
-	    assert(!this.paused);
-
-	    const { llhttp } = this;
-
-	    let ret;
-
-	    try {
-	      currentParser = this;
-	      ret = llhttp.llhttp_finish(this.ptr);
-	    } finally {
-	      currentParser = null;
-	    }
-
-	    if (ret === constants.ERROR.OK) {
-	      return null
-	    }
-
-	    if (ret === constants.ERROR.PAUSED || ret === constants.ERROR.PAUSED_UPGRADE) {
-	      this.paused = true;
-	      return null
-	    }
-
-	    return this.createError(ret, EMPTY_BUF)
-	  }
-
-	  createError (ret, data) {
-	    const { llhttp, contentLength, bytesRead } = this;
-
-	    if (contentLength && bytesRead !== parseInt(contentLength, 10)) {
-	      return new ResponseContentLengthMismatchError()
-	    }
-
-	    const ptr = llhttp.llhttp_get_error_reason(this.ptr);
-	    let message = '';
-	    if (ptr) {
-	      const len = new Uint8Array(llhttp.memory.buffer, ptr).indexOf(0);
-	      message =
-	        'Response does not match the HTTP/1.1 protocol (' +
-	        Buffer.from(llhttp.memory.buffer, ptr, len).toString() +
-	        ')';
-	    }
-
-	    return new HTTPParserError(message, constants.ERROR[ret], data)
 	  }
 
 	  destroy () {
@@ -9183,11 +9129,6 @@ function requireClientH1 () {
 
 	    /* istanbul ignore next: difficult to make a test case for */
 	    if (socket.destroyed) {
-	      return -1
-	    }
-
-	    if (client[kRunning] === 0) {
-	      util.destroy(socket, new SocketError('bad response', util.getSocketInfo(socket)));
 	      return -1
 	    }
 
@@ -9291,11 +9232,6 @@ function requireClientH1 () {
 
 	    /* istanbul ignore next: difficult to make a test case for */
 	    if (socket.destroyed) {
-	      return -1
-	    }
-
-	    if (client[kRunning] === 0) {
-	      util.destroy(socket, new SocketError('bad response', util.getSocketInfo(socket)));
 	      return -1
 	    }
 
@@ -9472,7 +9408,6 @@ function requireClientH1 () {
 	    request.onComplete(headers);
 
 	    client[kQueue][client[kRunningIdx]++] = null;
-	    socket[kSocketUsed] = true;
 
 	    if (socket[kWriting]) {
 	      assert(client[kRunning] === 0);
@@ -9531,9 +9466,6 @@ function requireClientH1 () {
 	  socket[kWriting] = false;
 	  socket[kReset] = false;
 	  socket[kBlocking] = false;
-	  socket[kIdleSocketValidation] = 0;
-	  socket[kIdleSocketValidationTimeout] = null;
-	  socket[kSocketUsed] = false;
 	  socket[kParser] = new Parser(client, socket, llhttpInstance);
 
 	  addListener(socket, 'error', function (err) {
@@ -9544,11 +9476,8 @@ function requireClientH1 () {
 	    // On Mac OS, we get an ECONNRESET even if there is a full body to be forwarded
 	    // to the user.
 	    if (err.code === 'ECONNRESET' && parser.statusCode && !parser.shouldKeepAlive) {
-	      const parserErr = parser.finish();
-	      if (parserErr) {
-	        this[kError] = parserErr;
-	        this[kClient][kOnError](parserErr);
-	      }
+	      // We treat all incoming data so for as a valid response.
+	      parser.onMessageComplete();
 	      return
 	    }
 
@@ -9567,10 +9496,8 @@ function requireClientH1 () {
 	    const parser = this[kParser];
 
 	    if (parser.statusCode && !parser.shouldKeepAlive) {
-	      const parserErr = parser.finish();
-	      if (parserErr) {
-	        util.destroy(this, parserErr);
-	      }
+	      // We treat all incoming data so far as a valid response.
+	      parser.onMessageComplete();
 	      return
 	    }
 
@@ -9580,11 +9507,10 @@ function requireClientH1 () {
 	    const client = this[kClient];
 	    const parser = this[kParser];
 
-	    clearIdleSocketValidation(this);
-
 	    if (parser) {
 	      if (!this[kError] && parser.statusCode && !parser.shouldKeepAlive) {
-	        this[kError] = parser.finish() || this[kError];
+	        // We treat all incoming data so far as a valid response.
+	        parser.onMessageComplete();
 	      }
 
 	      this[kParser].destroy();
@@ -9647,7 +9573,7 @@ function requireClientH1 () {
 	      return socket.destroyed
 	    },
 	    busy (request) {
-	      if (socket[kWriting] || socket[kReset] || socket[kBlocking] || socket[kIdleSocketValidation] === 1) {
+	      if (socket[kWriting] || socket[kReset] || socket[kBlocking]) {
 	        return true
 	      }
 
@@ -9685,31 +9611,6 @@ function requireClientH1 () {
 	  }
 	}
 
-	function clearIdleSocketValidation (socket) {
-	  if (socket[kIdleSocketValidationTimeout]) {
-	    clearTimeout(socket[kIdleSocketValidationTimeout]);
-	    socket[kIdleSocketValidationTimeout] = null;
-	  }
-
-	  socket[kIdleSocketValidation] = 0;
-	}
-
-	function scheduleIdleSocketValidation (client, socket) {
-	  socket[kIdleSocketValidation] = 1;
-	  socket[kIdleSocketValidationTimeout] = setTimeout(() => {
-	    socket[kIdleSocketValidationTimeout] = null;
-	    socket[kIdleSocketValidation] = 2;
-
-	    if (client[kSocket] === socket && !socket.destroyed) {
-	      client[kResume]();
-	    }
-	  }, 0);
-	  socket[kIdleSocketValidationTimeout].unref?.();
-	}
-
-	/**
-	 * @param {import('./client.js')} client
-	 */
 	function resumeH1 (client) {
 	  const socket = client[kSocket];
 
@@ -9722,32 +9623,6 @@ function requireClientH1 () {
 	    } else if (socket[kNoRef] && socket.ref) {
 	      socket.ref();
 	      socket[kNoRef] = false;
-	    }
-
-	    if (client[kRunning] === 0 && client[kPending] > 0 && socket[kSocketUsed]) {
-	      if (socket[kIdleSocketValidation] === 0) {
-	        scheduleIdleSocketValidation(client, socket);
-	        socket[kParser].readMore();
-	        if (socket.destroyed) {
-	          return
-	        }
-	        return
-	      }
-
-	      if (socket[kIdleSocketValidation] === 1) {
-	        socket[kParser].readMore();
-	        if (socket.destroyed) {
-	          return
-	        }
-	        return
-	      }
-	    }
-
-	    if (client[kRunning] === 0) {
-	      socket[kParser].readMore();
-	      if (socket.destroyed) {
-	        return
-	      }
 	    }
 
 	    if (client[kSize] === 0) {
@@ -9843,7 +9718,6 @@ function requireClientH1 () {
 	  }
 
 	  const socket = client[kSocket];
-	  clearIdleSocketValidation(socket);
 
 	  const abort = (err) => {
 	    if (request.aborted || request.completed) {
@@ -11414,10 +11288,9 @@ function requireClient () {
 	    autoSelectFamilyAttemptTimeout,
 	    // h2
 	    maxConcurrentStreams,
-	    allowH2,
-	    webSocket
+	    allowH2
 	  } = {}) {
-	    super({ webSocket });
+	    super();
 
 	    if (keepAlive !== undefined) {
 	      throw new InvalidArgumentError('unsupported keepAlive, use pipelining=0 instead')
@@ -12124,8 +11997,8 @@ function requirePoolBase () {
 	const kStats = Symbol('stats');
 
 	class PoolBase extends DispatcherBase {
-	  constructor (opts) {
-	    super(opts);
+	  constructor () {
+	    super();
 
 	    this[kQueue] = new FixedQueue();
 	    this[kClients] = [];
@@ -12344,6 +12217,8 @@ function requirePool () {
 	    allowH2,
 	    ...options
 	  } = {}) {
+	    super();
+
 	    if (connections != null && (!Number.isFinite(connections) || connections < 0)) {
 	      throw new InvalidArgumentError('invalid connections')
 	    }
@@ -12367,8 +12242,6 @@ function requirePool () {
 	        ...connect
 	      });
 	    }
-
-	    super(options);
 
 	    this[kInterceptors] = options.interceptors?.Pool && Array.isArray(options.interceptors.Pool)
 	      ? options.interceptors.Pool
@@ -12663,6 +12536,8 @@ function requireAgent () {
 
 	class Agent extends DispatcherBase {
 	  constructor ({ factory = defaultFactory, maxRedirections = 0, connect, ...options } = {}) {
+	    super();
+
 	    if (typeof factory !== 'function') {
 	      throw new InvalidArgumentError('factory must be a function.')
 	    }
@@ -12674,8 +12549,6 @@ function requireAgent () {
 	    if (!Number.isInteger(maxRedirections) || maxRedirections < 0) {
 	      throw new InvalidArgumentError('maxRedirections must be a positive number')
 	    }
-
-	    super(options);
 
 	    if (connect && typeof connect !== 'function') {
 	      connect = { ...connect };
@@ -24326,25 +24199,32 @@ function requireParse$1 () {
 	    // If the attribute-name case-insensitively matches the string
 	    // "SameSite", the user agent MUST process the cookie-av as follows:
 
-	    const attributeValueLowercase = attributeValue.toLowerCase();
+	    // 1. Let enforcement be "Default".
+	    let enforcement = 'Default';
 
-	    // 1. If cookie-av's attribute-value is a case-insensitive match for
-	    //    "None", append an attribute to the cookie-attribute-list with an
-	    //    attribute-name of "SameSite" and an attribute-value of "None".
-	    if (attributeValueLowercase === 'none') {
-	      cookieAttributeList.sameSite = 'None';
-	    } else if (attributeValueLowercase === 'strict') {
-	      // 2. If cookie-av's attribute-value is a case-insensitive match for
-	      //    "Strict", append an attribute to the cookie-attribute-list with
-	      //    an attribute-name of "SameSite" and an attribute-value of
-	      //    "Strict".
-	      cookieAttributeList.sameSite = 'Strict';
-	    } else if (attributeValueLowercase === 'lax') {
-	      // 3. If cookie-av's attribute-value is a case-insensitive match for
-	      //    "Lax", append an attribute to the cookie-attribute-list with an
-	      //    attribute-name of "SameSite" and an attribute-value of "Lax".
-	      cookieAttributeList.sameSite = 'Lax';
+	    const attributeValueLowercase = attributeValue.toLowerCase();
+	    // 2. If cookie-av's attribute-value is a case-insensitive match for
+	    //    "None", set enforcement to "None".
+	    if (attributeValueLowercase.includes('none')) {
+	      enforcement = 'None';
 	    }
+
+	    // 3. If cookie-av's attribute-value is a case-insensitive match for
+	    //    "Strict", set enforcement to "Strict".
+	    if (attributeValueLowercase.includes('strict')) {
+	      enforcement = 'Strict';
+	    }
+
+	    // 4. If cookie-av's attribute-value is a case-insensitive match for
+	    //    "Lax", set enforcement to "Lax".
+	    if (attributeValueLowercase.includes('lax')) {
+	      enforcement = 'Lax';
+	    }
+
+	    // 5. Append an attribute to the cookie-attribute-list with an
+	    //    attribute-name of "SameSite" and an attribute-value of
+	    //    enforcement.
+	    cookieAttributeList.sameSite = enforcement;
 	  } else {
 	    cookieAttributeList.unparsed ??= [];
 
@@ -25810,35 +25690,40 @@ function requirePermessageDeflate () {
 	const kBuffer = Symbol('kBuffer');
 	const kLength = Symbol('kLength');
 
+	// Default maximum decompressed message size: 4 MB
+	const kDefaultMaxDecompressedSize = 4 * 1024 * 1024;
+
 	class PerMessageDeflate {
 	  /** @type {import('node:zlib').InflateRaw} */
 	  #inflate
 
 	  #options = {}
 
-	  #maxPayloadSize = 0
+	  /** @type {boolean} */
+	  #aborted = false
+
+	  /** @type {Function|null} */
+	  #currentCallback = null
 
 	  /**
 	   * @param {Map<string, string>} extensions
 	   */
-	  constructor (extensions, options) {
+	  constructor (extensions) {
 	    this.#options.serverNoContextTakeover = extensions.has('server_no_context_takeover');
 	    this.#options.serverMaxWindowBits = extensions.get('server_max_window_bits');
-
-	    this.#maxPayloadSize = options.maxPayloadSize;
 	  }
 
-	  /**
-	   * Decompress a compressed payload.
-	   * @param {Buffer} chunk Compressed data
-	   * @param {boolean} fin Final fragment flag
-	   * @param {Function} callback Callback function
-	   */
 	  decompress (chunk, fin, callback) {
 	    // An endpoint uses the following algorithm to decompress a message.
 	    // 1.  Append 4 octets of 0x00 0x00 0xff 0xff to the tail end of the
 	    //     payload of the message.
 	    // 2.  Decompress the resulting data using DEFLATE.
+
+	    if (this.#aborted) {
+	      callback(new MessageSizeExceededError());
+	      return
+	    }
+
 	    if (!this.#inflate) {
 	      let windowBits = Z_DEFAULT_WINDOWBITS;
 
@@ -25861,12 +25746,23 @@ function requirePermessageDeflate () {
 	      this.#inflate[kLength] = 0;
 
 	      this.#inflate.on('data', (data) => {
+	        if (this.#aborted) {
+	          return
+	        }
+
 	        this.#inflate[kLength] += data.length;
 
-	        if (this.#maxPayloadSize > 0 && this.#inflate[kLength] > this.#maxPayloadSize) {
-	          callback(new MessageSizeExceededError());
+	        if (this.#inflate[kLength] > kDefaultMaxDecompressedSize) {
+	          this.#aborted = true;
 	          this.#inflate.removeAllListeners();
+	          this.#inflate.destroy();
 	          this.#inflate = null;
+
+	          if (this.#currentCallback) {
+	            const cb = this.#currentCallback;
+	            this.#currentCallback = null;
+	            cb(new MessageSizeExceededError());
+	          }
 	          return
 	        }
 
@@ -25879,13 +25775,14 @@ function requirePermessageDeflate () {
 	      });
 	    }
 
+	    this.#currentCallback = callback;
 	    this.#inflate.write(chunk);
 	    if (fin) {
 	      this.#inflate.write(tail);
 	    }
 
 	    this.#inflate.flush(() => {
-	      if (!this.#inflate) {
+	      if (this.#aborted || !this.#inflate) {
 	        return
 	      }
 
@@ -25893,6 +25790,7 @@ function requirePermessageDeflate () {
 
 	      this.#inflate[kBuffer].length = 0;
 	      this.#inflate[kLength] = 0;
+	      this.#currentCallback = null;
 
 	      callback(null, full);
 	    });
@@ -25928,12 +25826,6 @@ function requireReceiver () {
 	const { WebsocketFrameSend } = requireFrame();
 	const { closeWebSocketConnection } = requireConnection();
 	const { PerMessageDeflate } = requirePermessageDeflate();
-	const { MessageSizeExceededError } = requireErrors();
-
-	function failWebsocketConnectionWithCode (ws, code, reason) {
-	  closeWebSocketConnection(ws, code, reason, Buffer.byteLength(reason));
-	  failWebsocketConnection(ws, reason);
-	}
 
 	// This code was influenced by ws released under the MIT license.
 	// Copyright (c) 2011 Einar Otto Stangvik <einaros@gmail.com>
@@ -25942,7 +25834,6 @@ function requireReceiver () {
 
 	class ByteParser extends Writable {
 	  #buffers = []
-	  #fragmentsBytes = 0
 	  #byteOffset = 0
 	  #loop = false
 
@@ -25954,27 +25845,18 @@ function requireReceiver () {
 	  /** @type {Map<string, PerMessageDeflate>} */
 	  #extensions
 
-	  /** @type {number} */
-	  #maxFragments
-
-	  /** @type {number} */
-	  #maxPayloadSize
-
 	  /**
 	   * @param {import('./websocket').WebSocket} ws
 	   * @param {Map<string, string>|null} extensions
-	   * @param {{ maxFragments?: number, maxPayloadSize?: number }} [options]
 	   */
-	  constructor (ws, extensions, options = {}) {
+	  constructor (ws, extensions) {
 	    super();
 
 	    this.ws = ws;
 	    this.#extensions = extensions == null ? new Map() : extensions;
-	    this.#maxFragments = options.maxFragments ?? 0;
-	    this.#maxPayloadSize = options.maxPayloadSize ?? 0;
 
 	    if (this.#extensions.has('permessage-deflate')) {
-	      this.#extensions.set('permessage-deflate', new PerMessageDeflate(extensions, options));
+	      this.#extensions.set('permessage-deflate', new PerMessageDeflate(extensions));
 	    }
 	  }
 
@@ -25988,19 +25870,6 @@ function requireReceiver () {
 	    this.#loop = true;
 
 	    this.run(callback);
-	  }
-
-	  #validatePayloadLength () {
-	    if (
-	      this.#maxPayloadSize > 0 &&
-	      !isControlFrame(this.#info.opcode) &&
-	      this.#info.payloadLength + this.#fragmentsBytes > this.#maxPayloadSize
-	    ) {
-	      failWebsocketConnectionWithCode(this.ws, 1009, 'Payload size exceeds maximum allowed size');
-	      return false
-	    }
-
-	    return true
 	  }
 
 	  /**
@@ -26091,10 +25960,6 @@ function requireReceiver () {
 	        if (payloadLength <= 125) {
 	          this.#info.payloadLength = payloadLength;
 	          this.#state = parserStates.READ_DATA;
-
-	          if (!this.#validatePayloadLength()) {
-	            return
-	          }
 	        } else if (payloadLength === 126) {
 	          this.#state = parserStates.PAYLOADLENGTH_16;
 	        } else if (payloadLength === 127) {
@@ -26119,10 +25984,6 @@ function requireReceiver () {
 
 	        this.#info.payloadLength = buffer.readUInt16BE(0);
 	        this.#state = parserStates.READ_DATA;
-
-	        if (!this.#validatePayloadLength()) {
-	          return
-	        }
 	      } else if (this.#state === parserStates.PAYLOADLENGTH_64) {
 	        if (this.#byteOffset < 8) {
 	          return callback()
@@ -26145,10 +26006,6 @@ function requireReceiver () {
 
 	        this.#info.payloadLength = lower;
 	        this.#state = parserStates.READ_DATA;
-
-	        if (!this.#validatePayloadLength()) {
-	          return
-	        }
 	      } else if (this.#state === parserStates.READ_DATA) {
 	        if (this.#byteOffset < this.#info.payloadLength) {
 	          return callback()
@@ -26161,58 +26018,42 @@ function requireReceiver () {
 	          this.#state = parserStates.INFO;
 	        } else {
 	          if (!this.#info.compressed) {
-	            if (!this.writeFragments(body)) {
-	              return
-	            }
-
-	            if (this.#maxPayloadSize > 0 && this.#fragmentsBytes > this.#maxPayloadSize) {
-	              failWebsocketConnectionWithCode(this.ws, 1009, new MessageSizeExceededError().message);
-	              return
-	            }
+	            this.#fragments.push(body);
 
 	            // If the frame is not fragmented, a message has been received.
 	            // If the frame is fragmented, it will terminate with a fin bit set
 	            // and an opcode of 0 (continuation), therefore we handle that when
 	            // parsing continuation frames, not here.
 	            if (!this.#info.fragmented && this.#info.fin) {
-	              websocketMessageReceived(this.ws, this.#info.binaryType, this.consumeFragments());
+	              const fullMessage = Buffer.concat(this.#fragments);
+	              websocketMessageReceived(this.ws, this.#info.binaryType, fullMessage);
+	              this.#fragments.length = 0;
 	            }
 
 	            this.#state = parserStates.INFO;
 	          } else {
-	            this.#extensions.get('permessage-deflate').decompress(
-	              body,
-	              this.#info.fin,
-	              (error, data) => {
-	                if (error) {
-	                  const code = error instanceof MessageSizeExceededError ? 1009 : 1007;
-	                  failWebsocketConnectionWithCode(this.ws, code, error.message);
-	                  return
-	                }
-
-	                if (!this.writeFragments(data)) {
-	                  return
-	                }
-
-	                if (this.#maxPayloadSize > 0 && this.#fragmentsBytes > this.#maxPayloadSize) {
-	                  failWebsocketConnectionWithCode(this.ws, 1009, new MessageSizeExceededError().message);
-	                  return
-	                }
-
-	                if (!this.#info.fin) {
-	                  this.#state = parserStates.INFO;
-	                  this.#loop = true;
-	                  this.run(callback);
-	                  return
-	                }
-
-	                websocketMessageReceived(this.ws, this.#info.binaryType, this.consumeFragments());
-
-	                this.#loop = true;
-	                this.#state = parserStates.INFO;
-	                this.run(callback);
+	            this.#extensions.get('permessage-deflate').decompress(body, this.#info.fin, (error, data) => {
+	              if (error) {
+	                failWebsocketConnection(this.ws, error.message);
+	                return
 	              }
-	            );
+
+	              this.#fragments.push(data);
+
+	              if (!this.#info.fin) {
+	                this.#state = parserStates.INFO;
+	                this.#loop = true;
+	                this.run(callback);
+	                return
+	              }
+
+	              websocketMessageReceived(this.ws, this.#info.binaryType, Buffer.concat(this.#fragments));
+
+	              this.#loop = true;
+	              this.#state = parserStates.INFO;
+	              this.#fragments.length = 0;
+	              this.run(callback);
+	            });
 
 	            this.#loop = false;
 	            break
@@ -26262,35 +26103,6 @@ function requireReceiver () {
 	    this.#byteOffset -= n;
 
 	    return buffer
-	  }
-
-	  writeFragments (fragment) {
-	    if (
-	      this.#maxFragments > 0 &&
-	      this.#fragments.length === this.#maxFragments
-	    ) {
-	      failWebsocketConnectionWithCode(this.ws, 1008, 'Too many message fragments');
-	      return false
-	    }
-
-	    this.#fragmentsBytes += fragment.length;
-	    this.#fragments.push(fragment);
-	    return true
-	  }
-
-	  consumeFragments () {
-	    const fragments = this.#fragments;
-
-	    if (fragments.length === 1) {
-	      this.#fragmentsBytes = 0;
-	      return fragments.shift()
-	    }
-
-	    const output = Buffer.concat(fragments, this.#fragmentsBytes);
-	    this.#fragments = [];
-	    this.#fragmentsBytes = 0;
-
-	    return output
 	  }
 
 	  parseCloseBody (data) {
@@ -26978,14 +26790,7 @@ function requireWebsocket () {
 	    // once this happens, the connection is open
 	    this[kResponse] = response;
 
-	    const webSocketOptions = this[kController]?.dispatcher?.webSocketOptions;
-	    const maxFragments = webSocketOptions?.maxFragments;
-	    const maxPayloadSize = webSocketOptions?.maxPayloadSize;
-
-	    const parser = new ByteParser(this, parsedExtensions, {
-	      maxFragments,
-	      maxPayloadSize
-	    });
+	    const parser = new ByteParser(this, parsedExtensions);
 	    parser.on('drain', onParserDrain);
 	    parser.on('error', onParserError.bind(this));
 
@@ -30597,22 +30402,6 @@ function requireSemver$1 () {
 
 	const parseOptions = requireParseOptions();
 	const { compareIdentifiers } = requireIdentifiers();
-
-	const isPrereleaseIdentifier = (prerelease, identifier) => {
-	  const identifiers = identifier.split('.');
-	  if (identifiers.length > prerelease.length) {
-	    return false
-	  }
-
-	  for (let i = 0; i < identifiers.length; i++) {
-	    if (compareIdentifiers(prerelease[i], identifiers[i]) !== 0) {
-	      return false
-	    }
-	  }
-
-	  return true
-	};
-
 	class SemVer {
 	  constructor (version, options) {
 	    options = parseOptions(options);
@@ -30916,9 +30705,8 @@ function requireSemver$1 () {
 	          if (identifierBase === false) {
 	            prerelease = [identifier];
 	          }
-	          if (isPrereleaseIdentifier(this.prerelease, identifier)) {
-	            const prereleaseBase = this.prerelease[identifier.split('.').length];
-	            if (isNaN(prereleaseBase)) {
+	          if (compareIdentifiers(this.prerelease[0], identifier) === 0) {
+	            if (isNaN(this.prerelease[1])) {
 	              this.prerelease = prerelease;
 	            }
 	          } else {
@@ -31836,11 +31624,6 @@ function requireRange () {
 
 	const isX = id => !id || id.toLowerCase() === 'x' || id === '*';
 
-	const invalidXRangeOrder = (M, m, p) => (
-	  (isX(M) && !isX(m)) ||
-	  (isX(m) && p && !isX(p))
-	);
-
 	// ~, ~> --> * (any, kinda silly)
 	// ~2, ~2.x, ~2.x.x, ~>2, ~>2.x ~>2.x.x --> >=2.0.0 <3.0.0-0
 	// ~2.0, ~2.0.x, ~>2.0, ~>2.0.x --> >=2.0.0 <2.1.0-0
@@ -31858,10 +31641,6 @@ function requireRange () {
 
 	const replaceTilde = (comp, options) => {
 	  const r = options.loose ? re[t.TILDELOOSE] : re[t.TILDE];
-	  // if we're including prereleases in the match, then the lower bound is
-	  // -0, the lowest possible prerelease value, just like x-ranges and carets.
-	  // this keeps `~1.2` equivalent to the `1.2.x` x-range it's documented as.
-	  const z = options.includePrerelease ? '-0' : '';
 	  return comp.replace(r, (_, M, m, p, pr) => {
 	    debug('tilde', comp, _, M, m, p, pr);
 	    let ret;
@@ -31869,10 +31648,10 @@ function requireRange () {
 	    if (isX(M)) {
 	      ret = '';
 	    } else if (isX(m)) {
-	      ret = `>=${M}.0.0${z} <${+M + 1}.0.0-0`;
+	      ret = `>=${M}.0.0 <${+M + 1}.0.0-0`;
 	    } else if (isX(p)) {
 	      // ~1.2 == >=1.2.0 <1.3.0-0
-	      ret = `>=${M}.${m}.0${z} <${M}.${+m + 1}.0-0`;
+	      ret = `>=${M}.${m}.0 <${M}.${+m + 1}.0-0`;
 	    } else if (pr) {
 	      debug('replaceTilde pr', pr);
 	      ret = `>=${M}.${m}.${p}-${pr
@@ -31941,10 +31720,10 @@ function requireRange () {
 	      if (M === '0') {
 	        if (m === '0') {
 	          ret = `>=${M}.${m}.${p
-	          } <${M}.${m}.${+p + 1}-0`;
+	          }${z} <${M}.${m}.${+p + 1}-0`;
 	        } else {
 	          ret = `>=${M}.${m}.${p
-	          } <${M}.${+m + 1}.0-0`;
+	          }${z} <${M}.${+m + 1}.0-0`;
 	        }
 	      } else {
 	        ret = `>=${M}.${m}.${p
@@ -31970,10 +31749,6 @@ function requireRange () {
 	  const r = options.loose ? re[t.XRANGELOOSE] : re[t.XRANGE];
 	  return comp.replace(r, (ret, gtlt, M, m, p, pr) => {
 	    debug('xRange', comp, ret, gtlt, M, m, p, pr);
-	    if (invalidXRangeOrder(M, m, p)) {
-	      return comp
-	    }
-
 	    const xM = isX(M);
 	    const xm = xM || isX(m);
 	    const xp = xm || isX(p);
@@ -78015,7 +77790,7 @@ function getCacheServiceURL() {
     }
 }
 
-var version = "6.1.0";
+var version = "6.0.1";
 var require$$0 = {
 	version: version};
 
@@ -83665,19 +83440,57 @@ async function setUpNativeImageMusl() {
     addPath(join(toolPath, 'bin'));
 }
 
-// Keep in sync with https://github.com/actions/virtual-environments
+const VS_EDITIONS = ['Enterprise', 'Professional', 'Community', 'BuildTools'];
 const KNOWN_VISUAL_STUDIO_INSTALLATIONS = [
-    'C:\\Program Files\\Microsoft Visual Studio\\18\\Enterprise', // 'windows-2025' and 'windows-latest'
-    'C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise', // 'windows-2022'
-    'C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise', // 'windows-2019'
-    'C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Enterprise' // 'windows-2016' (deprecated and removed)
+    // 'windows-2025' and 'windows-latest'
+    ...VS_EDITIONS.map((e) => `C:\\Program Files\\Microsoft Visual Studio\\18\\${e}`),
+    // 'windows-2022'
+    ...VS_EDITIONS.map((e) => `C:\\Program Files\\Microsoft Visual Studio\\2022\\${e}`),
+    // 'windows-2019'
+    ...VS_EDITIONS.map((e) => `C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\${e}`),
+    // 'windows-2017'
+    ...VS_EDITIONS.map((e) => `C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\${e}`)
 ];
-if (process.env['VSINSTALLDIR']) {
-    // if VSINSTALLDIR is set, make it the first known installation
-    KNOWN_VISUAL_STUDIO_INSTALLATIONS.unshift(process.env['VSINSTALLDIR'].replace(/\\$/, ''));
-}
 const VCVARSALL_SUBPATH = 'VC\\Auxiliary\\Build\\vcvarsall.bat';
+const VSWHERE_PATH = 'C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer\\vswhere.exe';
+function findVcvarsallWithVswhere() {
+    if (!existsSync(VSWHERE_PATH)) {
+        debug('vswhere.exe not found, skipping');
+        return null;
+    }
+    try {
+        const output = execSync(`"${VSWHERE_PATH}" -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath -latest`, { shell: 'cmd' })
+            .toString()
+            .trim();
+        if (!output) {
+            debug('vswhere.exe returned no results');
+            return null;
+        }
+        const installationPath = output.split(/\r?\n/)[0].trim();
+        const candidate = `${installationPath}\\${VCVARSALL_SUBPATH}`;
+        if (existsSync(candidate)) {
+            debug(`Found vcvarsall.bat via vswhere: ${candidate}`);
+            return candidate;
+        }
+        debug(`vswhere reported "${installationPath}" but vcvarsall.bat not found there`);
+    }
+    catch (e) {
+        debug(`vswhere.exe failed: ${e}`);
+    }
+    return null;
+}
 function findVcvarsallPath() {
+    if (process.env['VSINSTALLDIR']) {
+        const vsinstalldir = process.env['VSINSTALLDIR'].replace(/\\$/, '');
+        const candidate = `${vsinstalldir}\\${VCVARSALL_SUBPATH}`;
+        if (existsSync(candidate)) {
+            return candidate;
+        }
+    }
+    const vswhereResult = findVcvarsallWithVswhere();
+    if (vswhereResult) {
+        return vswhereResult;
+    }
     for (const installation of KNOWN_VISUAL_STUDIO_INSTALLATIONS) {
         const candidate = `${installation}\\${VCVARSALL_SUBPATH}`;
         if (existsSync(candidate)) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,7 +32,17 @@ async function run(): Promise<void> {
     const isGraalVMforJDK17OrLater = distribution.length > 0 || graalVMVersion.length == 0
 
     if (c.IS_WINDOWS) {
-      setUpWindowsEnvironment()
+      try {
+        setUpWindowsEnvironment()
+      } catch (error) {
+        if (isGraalVMforJDK17OrLater) {
+          core.warning(
+            `${error instanceof Error ? error.message : error}. Native Image on JDK 17+ can detect the Windows environment automatically.`
+          )
+        } else {
+          throw error
+        }
+      }
     }
     await setUpDependencies(components)
     if (enableNativeImageMusl) {

--- a/src/msvc.ts
+++ b/src/msvc.ts
@@ -1,20 +1,62 @@
 import * as core from '@actions/core'
 import { execSync } from 'child_process'
 import { existsSync } from 'fs'
-// Keep in sync with https://github.com/actions/virtual-environments
+
+const VS_EDITIONS = ['Enterprise', 'Professional', 'Community', 'BuildTools']
 const KNOWN_VISUAL_STUDIO_INSTALLATIONS = [
-  'C:\\Program Files\\Microsoft Visual Studio\\18\\Enterprise', // 'windows-2025' and 'windows-latest'
-  'C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise', // 'windows-2022'
-  'C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise', // 'windows-2019'
-  'C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Enterprise' // 'windows-2016' (deprecated and removed)
+  // 'windows-2025' and 'windows-latest'
+  ...VS_EDITIONS.map((e) => `C:\\Program Files\\Microsoft Visual Studio\\18\\${e}`),
+  // 'windows-2022'
+  ...VS_EDITIONS.map((e) => `C:\\Program Files\\Microsoft Visual Studio\\2022\\${e}`),
+  // 'windows-2019'
+  ...VS_EDITIONS.map((e) => `C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\${e}`),
+  // 'windows-2017'
+  ...VS_EDITIONS.map((e) => `C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\${e}`)
 ]
-if (process.env['VSINSTALLDIR']) {
-  // if VSINSTALLDIR is set, make it the first known installation
-  KNOWN_VISUAL_STUDIO_INSTALLATIONS.unshift(process.env['VSINSTALLDIR'].replace(/\\$/, ''))
-}
 const VCVARSALL_SUBPATH = 'VC\\Auxiliary\\Build\\vcvarsall.bat'
+const VSWHERE_PATH = 'C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer\\vswhere.exe'
+
+function findVcvarsallWithVswhere(): string | null {
+  if (!existsSync(VSWHERE_PATH)) {
+    core.debug('vswhere.exe not found, skipping')
+    return null
+  }
+  try {
+    const output = execSync(
+      `"${VSWHERE_PATH}" -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath -latest`,
+      { shell: 'cmd' }
+    )
+      .toString()
+      .trim()
+    if (!output) {
+      core.debug('vswhere.exe returned no results')
+      return null
+    }
+    const installationPath = output.split(/\r?\n/)[0].trim()
+    const candidate = `${installationPath}\\${VCVARSALL_SUBPATH}`
+    if (existsSync(candidate)) {
+      core.debug(`Found vcvarsall.bat via vswhere: ${candidate}`)
+      return candidate
+    }
+    core.debug(`vswhere reported "${installationPath}" but vcvarsall.bat not found there`)
+  } catch (e) {
+    core.debug(`vswhere.exe failed: ${e}`)
+  }
+  return null
+}
 
 function findVcvarsallPath(): string {
+  if (process.env['VSINSTALLDIR']) {
+    const vsinstalldir = process.env['VSINSTALLDIR'].replace(/\\$/, '')
+    const candidate = `${vsinstalldir}\\${VCVARSALL_SUBPATH}`
+    if (existsSync(candidate)) {
+      return candidate
+    }
+  }
+  const vswhereResult = findVcvarsallWithVswhere()
+  if (vswhereResult) {
+    return vswhereResult
+  }
   for (const installation of KNOWN_VISUAL_STUDIO_INSTALLATIONS) {
     const candidate = `${installation}\\${VCVARSALL_SUBPATH}`
     if (existsSync(candidate)) {


### PR DESCRIPTION
## Summary

- Use `vswhere.exe` for dynamic Visual Studio detection, matching what GraalVM's own `native-image` does internally via `WindowsBuildEnvironmentUtil`
- Expand hardcoded paths to include all four VS editions (Enterprise, Professional, Community, BuildTools) as a fallback
- Preserve `VSINSTALLDIR` env var as the highest-priority override
- Downgrade MSVC setup failure to a warning for JDK 17+, since `native-image` performs its own VS detection in those versions

Detection order: `VSINSTALLDIR` → `vswhere.exe` → hardcoded paths.

Fixes #227.

## Test plan

- [ ] Verify on GitHub-hosted runners (`windows-latest`, `windows-2022`) — should work as before
- [ ] Verify on self-hosted runner with non-Enterprise VS edition (e.g. Community) — previously failed, should now succeed
- [ ] Verify `VSINSTALLDIR` env var override still works
- [ ] Verify JDK 17+ with no VS installation produces a warning (not a failure)